### PR TITLE
✨ [feat] 마이페이지 메인화면 UI 구현

### DIFF
--- a/lib/common/view/root_tab.dart
+++ b/lib/common/view/root_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/custom_navigation_bar.dart';
+import 'package:team_project_front/mypage/view/my_screen.dart';
 
 class RootTab extends StatefulWidget {
   const RootTab({super.key});
@@ -34,6 +35,7 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: _buildAppBar(),
       body: TabBarView(
         physics: NeverScrollableScrollPhysics(),
         controller: controller,
@@ -47,7 +49,7 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
           // CalendarScreen()
           Center(child: Container(child: Text('캘린더'))),
           // MyScreen()
-          Center(child: Container(child: Text('마이'))),
+          MyScreen(),
         ],
       ),
       bottomNavigationBar: CustomNavigationBar(
@@ -62,5 +64,45 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
       currentIndex = index;
       controller.animateTo(index);
     });
+  }
+
+  AppBar? _buildAppBar() {
+    switch(currentIndex) {
+      case 0:
+        return null;
+      case 1:
+        return AppBar(title: Text('홈캠'),);
+      case 2:
+        return null;
+      case 3:
+        return AppBar(title: Text('캘린더'));
+      case 4:
+        return AppBar(
+          title: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Text(
+              '마이페이지',
+              style: TextStyle(
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: IconButton(
+                  onPressed: () {},
+                  icon: Icon(
+                    Icons.settings,
+                    size: 36,
+                  ),
+
+              ),
+            )
+          ],
+        );
+      default:
+        return null;
+    }
   }
 }

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -1,0 +1,203 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class MyScreen extends StatefulWidget {
+  const MyScreen({super.key});
+
+  @override
+  State<MyScreen> createState() => _MyScreenState();
+}
+
+class _MyScreenState extends State<MyScreen> {
+  File? image;
+  List<String> members = ['김준형', '최강민'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(height: 24),
+        MyProfile(
+          image: image,
+          onPressedChangePic: () {},
+          onPressedChangeProfile: () {},
+        ),
+        SizedBox(height: 36),
+        FamilyProfile(
+            members: members,
+            onPressedAdd: () {},
+        )
+      ],
+    );
+  }
+}
+
+class MyProfile extends StatelessWidget {
+  File? image;
+  final GestureTapCallback? onPressedChangePic;
+  final VoidCallback? onPressedChangeProfile;
+
+  MyProfile({
+    required this.image,
+    required this.onPressedChangePic,
+    required this.onPressedChangeProfile,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Stack(
+          children: [
+            image != null ? CircleAvatar(
+              radius: 70,
+              backgroundColor: Colors.white,
+              backgroundImage: image != null ? FileImage(image!) : null,
+            ) : Icon(
+              Icons.account_circle,
+              size: 140,
+              color: ICON_GREY_COLOR,
+            ),
+            Positioned(
+              bottom: 0,
+              right: 4,
+              child: GestureDetector(
+                onTap: onPressedChangePic,
+                child: Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[50],
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.add_a_photo,
+                    color: ICON_GREY_COLOR,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: 12),
+        Text(
+          '보호자',
+          style: TextStyle(
+            fontWeight: FontWeight.w900,
+            fontSize: 24,
+          ),
+        ),
+        SizedBox(height: 4),
+        Text(
+          'jh010303',
+          style: TextStyle(
+            color: Colors.grey,
+            fontSize: 12,
+          ),
+        ),
+        SizedBox(height: 20),
+        ElevatedButton(
+          onPressed: onPressedChangeProfile,
+          style: ElevatedButton.styleFrom(
+            foregroundColor: Colors.white,
+            backgroundColor: MAIN_COLOR,
+            padding: EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+            elevation: 0,
+          ),
+          child: Text(
+            '내 정보 수정',
+            style: TextStyle(
+              fontSize: 16,
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class FamilyProfile extends StatelessWidget {
+  List<String> members;
+  final GestureTapCallback? onPressedAdd;
+
+  FamilyProfile({
+    required this.members,
+    required this.onPressedAdd,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          height: 1.0,
+          width: MediaQuery.of(context).size.width / 1.2,
+          color: ICON_GREY_COLOR,
+        ),
+        SizedBox(height: 28),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: EdgeInsets.only(left: 48),
+            child: Text(
+              '가족 구성원 관리',
+              style: TextStyle(
+                fontWeight: FontWeight.w900,
+                fontSize: 20,
+              ),
+            ),
+          ),
+        ),
+        SizedBox(height: 28),
+        Padding(
+          padding: EdgeInsets.only(left: 48),
+          child: Row(
+            children: [
+              ...members.map((name) =>
+                  Padding(
+                    padding: EdgeInsets.only(right: 24),
+                    child: Column(
+                      children: [
+                        CircleAvatar(
+                          radius: 30,
+                          backgroundColor: Colors.transparent,
+                          child: Icon(Icons.account_circle, size: 60, color: ICON_GREY_COLOR),
+                        ),
+                        SizedBox(height: 8,),
+                        Text(name),
+                      ],
+                    ),
+                  ),
+              ),
+              Column(
+                children: [
+                  CircleAvatar(
+                    radius: 30,
+                    backgroundColor: Colors.transparent,
+                    child: GestureDetector(
+                      onTap: onPressedAdd,
+                      child: Icon(Icons.add_circle, size: 60, color: ICON_GREY_COLOR),
+                    ),
+                  ),
+                  SizedBox(height: 8,),
+                  Text('추가하기'),
+                ],
+              )
+            ],
+          ),
+        ),
+        SizedBox(height: 36),
+        Container(
+          height: 1.0,
+          width: MediaQuery.of(context).size.width / 1.2,
+          color: ICON_GREY_COLOR,
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- AppBar는 root_tab.dart에서 각 탭(홈 = null, 홈캠, 지도 = null, 캘린더, 마이)별로 구현 
- AppBar를 null을 return한 탭(홈, 지도)은 AppBar 형태가 다르므로 따로 구현

- 마이페이지 메인 화면 기본 레이아웃 구성
- 현재 프로필(MyProfile), 가족 구성원 관리 UI(FamilyProfile) 포함
- 설정, 프로필 수정 및 추가 등 세부 페이지는 미구현 상태

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/11419e7b-951d-4fcb-a0bb-859eb1398763)

<br/>


## ➕ 이슈 링크

- [frontend #4]

<br/>
