### PR TITLE
✨ [Feat] 프로필 등록 UI 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.team_project_front"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>앱에서 프로필 사진을 설정하거나 갤러리에서 이미지를 선택하여 저장하기 위해 사진 라이브러리 접근이 필요합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>프로필 사진을 찍거나 사진을 찍어서 앱에 업로드하려면 카메라 권한이 필요합니다.</string>
 </dict>
 </plist>

--- a/lib/common/component/complete_dialog.dart
+++ b/lib/common/component/complete_dialog.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class CompleteDialog extends StatelessWidget {
+  final Widget image;
+  final String title;
+  final String content;
+  final String checkText;
+  final VoidCallback onPressedCheck;
+
+  const CompleteDialog({
+    required this.image,
+    required this.title,
+    required this.content,
+    required this.checkText,
+    required this.onPressedCheck,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            image,
+            SizedBox(height: 5),
+            Text(
+              title,
+              style: TextStyle(
+                fontWeight: FontWeight.w900,
+                fontSize: 18,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 10),
+            Text(
+              content,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: Colors.black87,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 24),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: MAIN_COLOR,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(15.0),
+                ),
+                elevation: 0,
+                minimumSize: Size(100, 40),
+              ).copyWith(
+                overlayColor: WidgetStateProperty.all(Colors.transparent),
+                splashFactory: NoSplash.splashFactory,
+                animationDuration: Duration.zero,
+                shadowColor: WidgetStateProperty.all(Colors.transparent),
+              ),
+              onPressed: onPressedCheck,
+              child: Text(
+                checkText,
+                style: TextStyle(
+                  fontSize: 18.0,
+                  fontWeight: FontWeight.w900,
+                  color: Colors.white,
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/component/custom_appbar_root_tab.dart
+++ b/lib/common/component/custom_appbar_root_tab.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class CustomAppbarRootTab extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final VoidCallback? onPressed;
+  final double height;
+
+  const CustomAppbarRootTab({
+    required this.title,
+    required this.onPressed,
+    required this.height,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      automaticallyImplyLeading: false,
+      title: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Text(title, style: TextStyle(fontWeight: FontWeight.w900)),
+      ),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: IconButton(
+            onPressed: onPressed,
+            icon: Icon(
+              Icons.settings,
+              size: 36,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(height);
+}

--- a/lib/common/component/navigation_button.dart
+++ b/lib/common/component/navigation_button.dart
@@ -8,7 +8,7 @@ class NavigationButton extends StatelessWidget {
   });
 
   final String text;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/common/component/yes_or_no_dialog.dart
+++ b/lib/common/component/yes_or_no_dialog.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class YesOrNoDialog extends StatelessWidget {
+  final String title;
+  final String content;
+  final VoidCallback onPressedYes;
+  final String yesText;
+  final String noText;
+
+
+  const YesOrNoDialog({
+    required this.title,
+    required this.content,
+    required this.onPressedYes,
+    required this.yesText,
+    required this.noText,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20.0),
+        side: BorderSide(
+          color: Colors.black26,
+          width: 1.0,
+        )
+      ),
+      title: Center(
+        child: Text(
+          title,
+          style: TextStyle(
+            fontWeight: FontWeight.w900,
+            fontSize: 20.0,
+          ),
+        ),
+      ),
+      content: SizedBox(
+        width: 280,
+        child: Text(
+          content,
+          style: TextStyle(
+            height: 1.9,
+            fontSize: 14.0,
+            color: Colors.black54,
+            fontWeight: FontWeight.w500
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+      actions: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: MAIN_COLOR,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20.0),
+                ),
+                elevation: 0,
+                minimumSize: Size(100, 40),
+              ).copyWith(
+                overlayColor: WidgetStateProperty.all(Colors.transparent),
+                splashFactory: NoSplash.splashFactory,
+                animationDuration: Duration.zero,
+                shadowColor: WidgetStateProperty.all(Colors.transparent),
+              ),
+              onPressed: () {
+                Navigator.of(context).pop();
+                onPressedYes();
+              },
+              child: Text(
+                yesText,
+                style: TextStyle(
+                  fontSize: 20.0,
+                  fontWeight: FontWeight.w900,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: MAIN_COLOR.withValues(alpha: 0.18),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20.0),
+                ),
+                elevation: 0,
+                minimumSize: Size(100, 40),
+              ).copyWith(
+                overlayColor: WidgetStateProperty.all(Colors.transparent),
+                splashFactory: NoSplash.splashFactory,
+                animationDuration: Duration.zero,
+                shadowColor: WidgetStateProperty.all(Colors.transparent),
+              ),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: Text(
+                noText,
+                style: TextStyle(
+                  fontSize: 20.0,
+                  fontWeight: FontWeight.w900,
+                  color: MAIN_COLOR,
+                ),
+              ),
+            )
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/lib/common/utils/image_picker_utils.dart
+++ b/lib/common/utils/image_picker_utils.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+import 'package:image_picker/image_picker.dart';
+
+Future<File?> pickImageFromGallery() async {
+  final ImagePicker picker = ImagePicker();
+  final XFile? pickedFile = await picker.pickImage(source: ImageSource.gallery);
+
+  if(pickedFile != null) {
+    return File(pickedFile.path);
+  } else {
+    return null;
+  }
+}

--- a/lib/common/view/root_tab.dart
+++ b/lib/common/view/root_tab.dart
@@ -6,7 +6,12 @@ import 'package:team_project_front/mypage/view/my_screen.dart';
 import 'package:team_project_front/settings/view/settings_screen.dart';
 
 class RootTab extends StatefulWidget {
-  const RootTab({super.key});
+  final int initialTabIndex;
+
+  const RootTab({
+    this.initialTabIndex = 0,
+    super.key,
+  });
 
   @override
   State<RootTab> createState() => _RootTabState();
@@ -19,7 +24,12 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
   @override
   void initState() {
     super.initState();
-    controller = TabController(length: 5, vsync: this);
+    currentIndex = widget.initialTabIndex;
+    controller = TabController(
+      length: 5,
+      vsync: this,
+      initialIndex: currentIndex,
+    );
     controller.addListener(tabListener);
   }
 
@@ -110,7 +120,7 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
         return 70.0;
       case 3:  // 캘린더
         return 70.0;
-      case 4:  // 마이페이지
+      case 4:  // 마이
         return 70.0;
       default:
         return 70.0;  // 기본값

--- a/lib/common/view/root_tab.dart
+++ b/lib/common/view/root_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:team_project_front/common/component/custom_appbar_root_tab.dart';
 import 'package:team_project_front/common/component/custom_navigation_bar.dart';
 import 'package:team_project_front/home/view/home.dart';
 import 'package:team_project_front/mypage/view/my_screen.dart';
@@ -67,41 +68,52 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
     });
   }
 
-  AppBar? _buildAppBar() {
+  PreferredSizeWidget? _buildAppBar() {
     switch (currentIndex) {
       case 0:
         return null;
-      case 1:
-        return AppBar(title: Text('홈캠'));
       case 2:
         return null;
+      case 1:
       case 3:
-        return AppBar(title: Text('캘린더'));
       case 4:
-        return AppBar(
-          title: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Text('마이페이지', style: TextStyle(fontWeight: FontWeight.w900)),
-          ),
-          actions: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: IconButton(
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => SettingsScreen())
-                    );
-                  },
-                  icon: Icon(
-                    Icons.settings,
-                    size: 36,
-                  ),
-              ),
-            ),
-          ],
+        return CustomAppbarRootTab(
+          title: getAppBarTitle(),
+          height: getAppBarHeight(),
+          onPressed: () {
+            Navigator.of(context).push(
+                MaterialPageRoute(builder: (context) => SettingsScreen())
+            );
+          },
         );
       default:
         return null;
+    }
+  }
+
+  String getAppBarTitle() {
+    switch (currentIndex) {
+      case 1:
+        return '홈캠';
+      case 3:
+        return '캘린더';
+      case 4:
+        return '마이페이지';
+      default:
+        return '';
+    }
+  }
+
+  double getAppBarHeight() {
+    switch (currentIndex) {
+      case 1:  // 홈캠
+        return 70.0;
+      case 3:  // 캘린더
+        return 70.0;
+      case 4:  // 마이페이지
+        return 70.0;
+      default:
+        return 70.0;  // 기본값
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,7 @@ class _App extends StatelessWidget {
       // home: RootTab(),
       // Named Routes 적용 화면 개발시 initialRoute를 바꿔주면서 진행하면 편리합니다.
       // ex) login 화면 개발 중이라면 initialRoute: '/login',
-      initialRoute: '/signup',
+      initialRoute: '/home',
       routes: {
         '/': (context) => InitScreen(),
         '/home': (context) => RootTab(),

--- a/lib/mypage/component/illness_selctor.dart
+++ b/lib/mypage/component/illness_selctor.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class IllnessSelector extends StatelessWidget {
+  final List<String> illnesses;
+  final Set<String> selectedIllnesses;
+  final ValueChanged<Set<String>> onSelectionChanged;
+
+  const IllnessSelector({
+    super.key,
+    required this.illnesses,
+    required this.selectedIllnesses,
+    required this.onSelectionChanged,
+  });
+
+  String getDisplayText(String illness) {
+    return illness == '면역력 저하' ? '면역력\n저하' : illness;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '진단받은 질환',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 15),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final buttonWidth = (constraints.maxWidth - 20) / 3;
+
+            return Wrap(
+              spacing: 10,
+              runSpacing: 15,
+              children: illnesses.map((illness) {
+                final isSelected = selectedIllnesses.contains(illness);
+                final isFullWidth = illness == '해당 없음';
+
+                return SizedBox(
+                  width: isFullWidth ? constraints.maxWidth : buttonWidth,
+                  height: 60,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      final updated = Set<String>.from(selectedIllnesses);
+                      if (illness == '해당 없음') {
+                        updated
+                          ..clear()
+                          ..add('해당 없음');
+                      } else {
+                        updated.remove('해당 없음');
+                        isSelected ? updated.remove(illness) : updated.add(illness);
+                      }
+                      onSelectionChanged(updated);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: isSelected
+                          ? MAIN_COLOR.withOpacity(0.13)
+                          : Theme.of(context).scaffoldBackgroundColor,
+                      foregroundColor: isSelected ? MAIN_COLOR : Colors.black54,
+                      side: BorderSide(
+                        color: isSelected ? MAIN_COLOR : ICON_GREY_COLOR,
+                        width: 1.5,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      elevation: 0,
+                    ).copyWith(
+                      overlayColor: WidgetStateProperty.all(Colors.transparent),
+                      splashFactory: NoSplash.splashFactory,
+                      animationDuration: Duration.zero,
+                      shadowColor: WidgetStateProperty.all(Colors.transparent),
+                    ),
+                    child: Text(
+                      getDisplayText(illness),
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                );
+              }).toList(),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mypage/component/profile_birth_input.dart
+++ b/lib/mypage/component/profile_birth_input.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/mypage/utils/date_picker_utils.dart';
+
+class ProfileBirthInput extends StatelessWidget {
+  final String? yearText;
+  final String? monthText;
+  final String? dayText;
+  final Function(String) onYearSelected;
+  final Function(String) onMonthSelected;
+  final Function(String) onDaySelected;
+
+  const ProfileBirthInput({
+    super.key,
+    required this.yearText,
+    required this.monthText,
+    required this.dayText,
+    required this.onYearSelected,
+    required this.onMonthSelected,
+    required this.onDaySelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '생년월일',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: _buildDateField(
+                context: context,
+                text: yearText,
+                hintText: '0000',
+                onTap: () => showYearPicker(
+                  context: context,
+                  initialYear: yearText,
+                  onSelected: onYearSelected,
+                ),
+              ),
+            ),
+            SizedBox(width: 6),
+            Text('년'),
+            SizedBox(width: 10),
+            Expanded(
+              child: _buildDateField(
+                context: context,
+                text: monthText,
+                hintText: '00',
+                onTap: () => showMonthPicker(
+                  context: context,
+                  initialMonth: monthText,
+                  onSelected: onMonthSelected,
+                ),
+              ),
+            ),
+            SizedBox(width: 6),
+            Text('월'),
+            SizedBox(width: 10),
+            Expanded(
+              child: _buildDateField(
+                context: context,
+                text: dayText,
+                hintText: '00',
+                onTap: () => showDayPicker(
+                  context: context,
+                  initialDay: dayText,
+                  onSelected: onDaySelected,
+                ),
+              ),
+            ),
+            SizedBox(width: 6),
+            Text('일'),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDateField({
+    required BuildContext context,
+    required String? text,
+    required String hintText,
+    required VoidCallback onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AbsorbPointer(
+        child: TextFormField(
+          textAlign: TextAlign.center,
+          readOnly: true,
+          decoration: InputDecoration(
+            hintText: hintText,
+            hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
+            ),
+          ),
+          controller: TextEditingController(text: text),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/mypage/component/profile_body_info_input.dart
+++ b/lib/mypage/component/profile_body_info_input.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class ProfileBodyInfoInput extends StatelessWidget {
+  final TextEditingController heightController;
+  final TextEditingController weightController;
+  final String? Function(String?)? validateHeight;
+  final String? Function(String?)? validateWeight;
+
+  const ProfileBodyInfoInput({
+    super.key,
+    required this.heightController,
+    required this.weightController,
+    this.validateHeight,
+    this.validateWeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildLabeledInput(
+            label: '키',
+            unit: 'cm',
+            controller: heightController,
+            validator: validateHeight,
+          ),
+        ),
+        SizedBox(width: 20),
+        Expanded(
+          child: _buildLabeledInput(
+            label: '몸무게',
+            unit: 'kg',
+            controller: weightController,
+            validator: validateWeight,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLabeledInput({
+    required String label,
+    required String unit,
+    required TextEditingController controller,
+    String? Function(String?)? validator,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+        )),
+        const SizedBox(height: 6),
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                controller: controller,
+                validator: validator,
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+                decoration: InputDecoration(
+                  hintText: '0.0',
+                  hintStyle: const TextStyle(color: INPUT_BORDER_COLOR),
+                  contentPadding: const EdgeInsets.symmetric(vertical: 16),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: ICON_GREY_COLOR, width: 1.5),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: MAIN_COLOR, width: 2.0),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(unit),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mypage/component/profile_gender_selector.dart
+++ b/lib/mypage/component/profile_gender_selector.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class ProfileGenderSelector extends StatelessWidget {
+  final String? selectedGender;
+  final ValueChanged<String> onGenderSelected;
+
+  const ProfileGenderSelector({
+    super.key,
+    required this.selectedGender,
+    required this.onGenderSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final List<String> genders = ['여자', '남자'];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '성별',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            for (int i = 0; i < genders.length; i++) ...[
+              Expanded(
+                child: SizedBox(
+                  height: 60,
+                  child: ElevatedButton(
+                    onPressed: () => onGenderSelected(genders[i]),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: selectedGender == genders[i]
+                          ? MAIN_COLOR.withAlpha(33)
+                          : Theme.of(context).scaffoldBackgroundColor,
+                      foregroundColor: selectedGender == genders[i]
+                          ? MAIN_COLOR
+                          : Colors.black54,
+                      side: BorderSide(
+                        color: selectedGender == genders[i]
+                            ? MAIN_COLOR
+                            : ICON_GREY_COLOR,
+                        width: 1.5,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      elevation: 0,
+                    ).copyWith(
+                      overlayColor: WidgetStateProperty.all(Colors.transparent),
+                      splashFactory: NoSplash.splashFactory,
+                      animationDuration: Duration.zero,
+                      shadowColor: WidgetStateProperty.all(Colors.transparent),
+                    ),
+                    child: Text(
+                      genders[i],
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              if (i != genders.length - 1) const SizedBox(width: 16),
+            ]
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mypage/component/profile_image_with_add_icon.dart
+++ b/lib/mypage/component/profile_image_with_add_icon.dart
@@ -8,6 +8,7 @@ class ProfileImageWithAddIcon extends StatelessWidget {
   final double addImageIconSize;
   final double bottom;
   final double right;
+  final double radius;
   final GestureTapCallback? onPressedChangePic;
 
   const ProfileImageWithAddIcon({
@@ -16,6 +17,7 @@ class ProfileImageWithAddIcon extends StatelessWidget {
     required this.addImageIconSize,
     required this.bottom,
     required this.right,
+    required this.radius,
     required this.onPressedChangePic,
     super.key,
   });
@@ -26,7 +28,7 @@ class ProfileImageWithAddIcon extends StatelessWidget {
       children: [
         image != null
             ? CircleAvatar(
-          radius: 70,
+          radius: radius,
           backgroundColor: Colors.white,
           backgroundImage: image != null ? FileImage(image!) : null,
         )

--- a/lib/mypage/component/profile_image_with_add_icon.dart
+++ b/lib/mypage/component/profile_image_with_add_icon.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class ProfileImageWithAddIcon extends StatelessWidget {
+  final File? image;
+  final double profileIconSize;
+  final double addImageIconSize;
+  final double bottom;
+  final double right;
+  final GestureTapCallback? onPressedChangePic;
+
+  const ProfileImageWithAddIcon({
+    required this.image,
+    required this.profileIconSize,
+    required this.addImageIconSize,
+    required this.bottom,
+    required this.right,
+    required this.onPressedChangePic,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        image != null
+            ? CircleAvatar(
+          radius: 70,
+          backgroundColor: Colors.white,
+          backgroundImage: image != null ? FileImage(image!) : null,
+        )
+            : Icon(
+          Icons.account_circle,
+          size: profileIconSize,
+          color: ICON_GREY_COLOR,
+        ),
+        Positioned(
+          bottom: bottom,
+          right: right,
+          child: GestureDetector(
+            onTap: onPressedChangePic,
+            child: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.grey[50],
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.add_a_photo,
+                size: addImageIconSize,
+                color: ICON_GREY_COLOR,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mypage/component/profile_name_input.dart
+++ b/lib/mypage/component/profile_name_input.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/component/custom_input.dart';
+
+class ProfileNameInput extends StatelessWidget {
+  final TextEditingController controller;
+
+  const ProfileNameInput({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '이름 / 닉네임',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        SizedBox(height: 10),
+        CustomTextFormField(
+          controller: controller,
+          hintText: '이름 또는 애칭 입력(2-8자)',
+          validator: (val) {
+            if (val == null || val.isEmpty) {
+              return '이름을 입력해주세요';
+            }
+            if (val.length < 2 || val.length > 8) {
+              return '2~8자 이내로 입력해주세요';
+            }
+            if (!RegExp(r'^[a-zA-Z가-힣]+$').hasMatch(val)) {
+              return '한글 또는 영문만 입력 가능합니다';
+            }
+            return null;
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mypage/component/seizure_history_selector.dart
+++ b/lib/mypage/component/seizure_history_selector.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class SeizureHistorySelector extends StatelessWidget {
+  final String? selected;
+  final List<String> options;
+  final ValueChanged<String> onSelected;
+
+  const SeizureHistorySelector({
+    super.key,
+    required this.selected,
+    required this.options,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '열성경련 이력',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 15),
+        Row(
+          children: [
+            for (int i = 0; i < options.length; i++) ...[
+              Expanded(
+                child: SizedBox(
+                  height: 60,
+                  child: ElevatedButton(
+                    onPressed: () => onSelected(options[i]),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: selected == options[i]
+                          ? MAIN_COLOR.withOpacity(0.13)
+                          : Theme.of(context).scaffoldBackgroundColor,
+                      foregroundColor: selected == options[i]
+                          ? MAIN_COLOR
+                          : Colors.black54,
+                      side: BorderSide(
+                        color: selected == options[i]
+                            ? MAIN_COLOR
+                            : ICON_GREY_COLOR,
+                        width: 1.5,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      elevation: 0,
+                    ).copyWith(
+                      overlayColor: WidgetStateProperty.all(Colors.transparent),
+                      splashFactory: NoSplash.splashFactory,
+                      animationDuration: Duration.zero,
+                      shadowColor: WidgetStateProperty.all(Colors.transparent),
+                    ),
+                    child: Text(
+                      options[i],
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              if (i != options.length - 1) const SizedBox(width: 12),
+            ]
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mypage/models/profile_info.dart
+++ b/lib/mypage/models/profile_info.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+class ProfileInfo {
+  final String name;
+  final String birthYear;
+  final String birthMonth;
+  final String birthDay;
+  final double height;
+  final double weight;
+  final String gender;
+  final String? seizureHistory;
+  final List<String>? illnessList;
+  final File? image;
+
+  ProfileInfo({
+    required this.name,
+    required this.birthYear,
+    required this.birthMonth,
+    required this.birthDay,
+    required this.height,
+    required this.weight,
+    required this.gender,
+    this.seizureHistory,
+    this.illnessList,
+    this.image,
+  });
+
+  ProfileInfo copyWith({
+    String? name,
+    String? birthYear,
+    String? birthMonth,
+    String? birthDay,
+    double? height,
+    double? weight,
+    String? gender,
+    String? seizureHistory,
+    List<String>? illnessList,
+    File? image,
+  }) {
+    return ProfileInfo(
+      name: name ?? this.name,
+      birthYear: birthYear ?? this.birthYear,
+      birthMonth: birthMonth ?? this.birthMonth,
+      birthDay: birthDay ?? this.birthDay,
+      height: height ?? this.height,
+      weight: weight ?? this.weight,
+      gender: gender ?? this.gender,
+      seizureHistory: seizureHistory ?? this.seizureHistory,
+      illnessList: illnessList ?? this.illnessList,
+      image: image ?? this.image,
+    );
+  }
+}

--- a/lib/mypage/utils/date_picker_utils.dart
+++ b/lib/mypage/utils/date_picker_utils.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+Future<void> showYearPicker({
+  required BuildContext context,
+  required void Function(String year) onSelected,
+  String? initialYear,
+}) async {
+  final currentYear = DateTime.now().year;
+  final years = List.generate(100, (index) => (currentYear - index).toString());
+
+  await showCupertinoModalPopup(
+    context: context,
+    builder: (_) => Container(
+      height: 250,
+      color: Colors.white,
+      child: Column(
+        children: [
+          Expanded(
+            child: CupertinoPicker(
+              scrollController: FixedExtentScrollController(
+                initialItem: initialYear != null
+                    ? years.indexOf(initialYear)
+                    : 0,
+              ),
+              itemExtent: 40,
+              onSelectedItemChanged: (index) {
+                onSelected(years[index]);
+              },
+              children: years.map((y) => Center(child: Text('$y년'))).toList(),
+            ),
+          ),
+          CupertinoButton(
+            child: Text('확인'),
+            onPressed: () => Navigator.pop(context),
+          )
+        ],
+      ),
+    ),
+  );
+}
+
+Future<void> showMonthPicker({
+  required BuildContext context,
+  required void Function(String month) onSelected,
+  String? initialMonth,
+}) async {
+  final months = List.generate(12, (i) => (i + 1).toString().padLeft(2, '0'));
+
+  await showCupertinoModalPopup(
+    context: context,
+    builder: (_) => Container(
+      height: 250,
+      color: Colors.white,
+      child: Column(
+        children: [
+          Expanded(
+            child: CupertinoPicker(
+              scrollController: FixedExtentScrollController(
+                initialItem: initialMonth != null
+                    ? months.indexOf(initialMonth)
+                    : 0,
+              ),
+              itemExtent: 40,
+              onSelectedItemChanged: (index) {
+                onSelected(months[index]);
+              },
+              children: months.map((m) => Center(child: Text('$m월'))).toList(),
+            ),
+          ),
+          CupertinoButton(
+            child: Text('확인'),
+            onPressed: () => Navigator.pop(context),
+          )
+        ],
+      ),
+    ),
+  );
+}
+
+Future<void> showDayPicker({
+  required BuildContext context,
+  required void Function(String day) onSelected,
+  String? initialDay,
+}) async {
+  final days = List.generate(31, (i) => (i + 1).toString().padLeft(2, '0'));
+
+  await showCupertinoModalPopup(
+    context: context,
+    builder: (_) => Container(
+      height: 250,
+      color: Colors.white,
+      child: Column(
+        children: [
+          Expanded(
+            child: CupertinoPicker(
+              scrollController: FixedExtentScrollController(
+                initialItem: initialDay != null
+                    ? days.indexOf(initialDay)
+                    : 0,
+              ),
+              itemExtent: 40,
+              onSelectedItemChanged: (index) {
+                onSelected(days[index]);
+              },
+              children: days.map((d) => Center(child: Text('$d일'))).toList(),
+            ),
+          ),
+          CupertinoButton(
+            child: Text('확인'),
+            onPressed: () => Navigator.pop(context),
+          )
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/mypage/utils/image_pick_handler.dart
+++ b/lib/mypage/utils/image_pick_handler.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/utils/image_picker_utils.dart';
+
+Future<void> handleImagePick({
+  required BuildContext context,
+  required void Function(File image) onImageSelected,
+}) async {
+  final selectedImage = await pickImageFromGallery();
+
+  if (selectedImage != null) {
+    onImageSelected(selectedImage);
+  } else {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('사진이 선택되지 않았습니다.')),
+    );
+  }
+}

--- a/lib/mypage/utils/validators.dart
+++ b/lib/mypage/utils/validators.dart
@@ -1,0 +1,17 @@
+String? validateHeight(String? value) {
+  if (value == null || value.isEmpty) return '값을 입력해주세요';
+  final parsed = double.tryParse(value);
+  if (parsed == null) return '숫자만 입력해주세요';
+  if (parsed < 0 || parsed > 200) return '0~200 사이로 입력해주세요';
+  if (!RegExp(r'^\d{1,3}(\.\d)?$').hasMatch(value)) return '소수 첫째자리까지 입력해주세요';
+  return null;
+}
+
+String? validateWeight(String? value) {
+  if (value == null || value.isEmpty) return '값을 입력해주세요';
+  final parsed = double.tryParse(value);
+  if (parsed == null) return '숫자만 입력해주세요';
+  if (parsed < 0 || parsed > 100) return '0~100 사이로 입력해주세요';
+  if (!RegExp(r'^\d{1,3}(\.\d)?$').hasMatch(value)) return '소수 첫째자리까지 입력해주세요';
+  return null;
+}

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -1,0 +1,555 @@
+import 'dart:io';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/component/custom_input.dart';
+import 'package:team_project_front/common/component/navigation_button.dart';
+import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
+import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
+import 'package:team_project_front/settings/component/custom_appbar.dart';
+
+class ProfileInfo {
+  final String name;
+  final String birthYear;
+  final String birthMonth;
+  final String birthDay;
+  final double height;
+  final double weight;
+  final String gender;
+  final String? seizureHistory;
+  final List<String>? illnessList;
+  final File? image;
+  
+  ProfileInfo({
+    required this.name,
+    required this.birthYear,
+    required this.birthMonth,
+    required this.birthDay,
+    required this.height,
+    required this.weight,
+    required this.gender,
+    this.seizureHistory,
+    this.illnessList,
+    this.image,
+  });
+
+  ProfileInfo copyWith({
+    String? name,
+    String? birthYear,
+    String? birthMonth,
+    String? birthDay,
+    double? height,
+    double? weight,
+    String? gender,
+    String? seizureHistory,
+    List<String>? illnessList,
+    File? image,
+  }) {
+    return ProfileInfo(
+      name: name ?? this.name,
+      birthYear: birthYear ?? this.birthYear,
+      birthMonth: birthMonth ?? this.birthMonth,
+      birthDay: birthDay ?? this.birthDay,
+      height: height ?? this.height,
+      weight: weight ?? this.weight,
+      gender: gender ?? this.gender,
+      seizureHistory: seizureHistory ?? this.seizureHistory,
+      illnessList: illnessList ?? this.illnessList,
+      image: image ?? this.image,
+    );
+  }
+}
+
+class AddProfileScreen extends StatefulWidget {
+  const AddProfileScreen({super.key});
+
+  @override
+  State<AddProfileScreen> createState() => _AddProfileScreenState();
+}
+
+class _AddProfileScreenState extends State<AddProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController heightController = TextEditingController();
+  final TextEditingController weightController = TextEditingController();
+  DateTime selectedDate = DateTime.now();
+  String? yearText;
+  String? monthText;
+  String? dayText;
+  double height = 10.0;
+  double weight = 10.0;
+  String? gender;
+  File? image;
+
+  final List<String> genders = ['여자', '남자'];
+
+  bool get isFormValid =>
+    _formKey.currentState?.validate() == true &&
+    yearText != null &&
+    monthText != null &&
+    dayText != null &&
+    gender != null;
+
+  void onNextPressed() {
+    if(!isFormValid) return;
+
+    final profileInfo = ProfileInfo(
+      name: nameController.text.trim(),
+      birthYear: yearText!,
+      birthMonth: monthText!,
+      birthDay: dayText!,
+      height: double.parse(heightController.text),
+      weight: double.parse(weightController.text),
+      gender: gender!,
+      image: image,
+    );
+    
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => AddProfileSymptomsScreen(
+        profileInfo: profileInfo,
+      )),
+    );
+  }
+
+  void selectedYear() {
+    final currentYear = DateTime.now().year;
+    final years = List.generate(100, (index) => (currentYear - index).toString());
+
+    showCupertinoModalPopup(
+      context: context,
+      builder: (_) => Container(
+        height: 250,
+        color: Colors.white,
+        child: Column(
+          children: [
+            Expanded(
+              child: CupertinoPicker(
+                scrollController: FixedExtentScrollController(
+                  initialItem: yearText != null
+                    ? years.indexOf(yearText!)
+                    : 0,
+                ),
+                itemExtent: 40,
+                onSelectedItemChanged: (index) {
+                  setState(() {
+                    yearText = years[index];
+                  });
+                },
+                children: years.map((y) => Center(child: Text('$y년'))).toList(),
+              ),
+            ),
+            CupertinoButton(
+              child: Text('확인'),
+              onPressed: () => Navigator.pop(context),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+
+  void selectMonth() {
+    final months = List.generate(12, (i) => (i + 1).toString().padLeft(2, '0'));
+
+    showCupertinoModalPopup(
+      context: context,
+      builder: (_) => Container(
+        height: 250,
+        color: Colors.white,
+        child: Column(
+          children: [
+            Expanded(
+              child: CupertinoPicker(
+                scrollController: FixedExtentScrollController(
+                  initialItem: monthText != null
+                      ? months.indexOf(monthText!)
+                      : 0,
+                ),
+                itemExtent: 40,
+                onSelectedItemChanged: (index) {
+                  setState(() {
+                    monthText = months[index];
+                  });
+                },
+                children: months.map((m) => Center(child: Text('$m월'))).toList(),
+              ),
+            ),
+            CupertinoButton(
+              child: Text('확인'),
+              onPressed: () => Navigator.pop(context),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+
+  void selectDay() {
+    final days = List.generate(31, (i) => (i + 1).toString().padLeft(2, '0'));
+
+    showCupertinoModalPopup(
+      context: context,
+      builder: (_) => Container(
+        height: 250,
+        color: Colors.white,
+        child: Column(
+          children: [
+            Expanded(
+              child: CupertinoPicker(
+                scrollController: FixedExtentScrollController(
+                  initialItem: dayText != null
+                      ? days.indexOf(dayText!)
+                      : 0,
+                ),
+                itemExtent: 40,
+                onSelectedItemChanged: (index) {
+                  setState(() {
+                    dayText = days[index];
+                  });
+                },
+                children: days.map((d) => Center(child: Text('$d일'))).toList(),
+              ),
+            ),
+            CupertinoButton(
+              child: Text('확인'),
+              onPressed: () => Navigator.pop(context),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+
+  String? validateHeight(String? value) {
+    if (value == null || value.isEmpty) return '값을 입력해주세요';
+    final parsed = double.tryParse(value);
+    if (parsed == null) return '숫자만 입력해주세요';
+    if (parsed < 0 || parsed > 200) return '0~200 사이로 입력해주세요';
+    if (!RegExp(r'^\d{1,3}(\.\d)?$').hasMatch(value)) return '소수 첫째자리까지 입력해주세요';
+    return null;
+  }
+
+  String? validateWeight(String? value) {
+    if (value == null || value.isEmpty) return '값을 입력해주세요';
+    final parsed = double.tryParse(value);
+    if (parsed == null) return '숫자만 입력해주세요';
+    if (parsed < 0 || parsed > 100) return '0~100 사이로 입력해주세요';
+    if (!RegExp(r'^\d{1,3}(\.\d)?$').hasMatch(value)) return '소수 첫째자리까지 입력해주세요';
+    return null;
+  }
+
+  GestureTapCallback? onPressedChangePic() {
+    // 이미지 선택 로직 구현 예정
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(90),
+        child: CustomAppbar(
+          title: '프로필 등록',
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.symmetric(horizontal: 30),
+        child: Form(
+          key: _formKey,
+          onChanged: () => setState(() {}),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: ProfileImageWithAddIcon(
+                    image: image,
+                    profileIconSize: 90,
+                    addImageIconSize: 18,
+                    bottom: 0,
+                    right: -5,
+                    onPressedChangePic: onPressedChangePic,
+                ),
+              ),
+              SizedBox(height: 15),
+              Text(
+                '우리 아이 정보를 알려주세요',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              SizedBox(height: 20),
+              Text(
+                '이름 / 닉네임',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              SizedBox(height: 10),
+              CustomTextFormField(
+                controller: nameController,
+                hintText: '이름 또는 애칭 입력(2-8자)',
+                validator: (val) {
+                  if (val == null || val.isEmpty) {
+                    return '이름을 입력해주세요';
+                  }
+                  if (val.length < 2 || val.length > 8) {
+                    return '2~8자 이내로 입력해주세요';
+                  }
+                  if (!RegExp(r'^[a-zA-Z가-힣]+$').hasMatch(val)) {
+                    return '한글 또는 영문만 입력 가능합니다';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: 20),
+              Text(
+                '생년월일',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              SizedBox(height: 10),
+              Row(
+                children: [
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: selectedYear,
+                      child: AbsorbPointer(
+                        child: TextFormField(
+                          textAlign: TextAlign.center,
+                          readOnly: true,
+                          decoration: InputDecoration(
+                            hintText: '0000',
+                            hintStyle: TextStyle(
+                              color: INPUT_BORDER_COLOR,
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(
+                                color: ICON_GREY_COLOR,
+                                width: 1.5,
+                              )
+                            ),
+                          ),
+                          controller: TextEditingController(text: yearText),
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: 6),
+                  Text('년'),
+                  SizedBox(width: 10),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: selectMonth,
+                      child: AbsorbPointer(
+                        child: TextFormField(
+                          textAlign: TextAlign.center,
+                          readOnly: true,
+                          decoration: InputDecoration(
+                            hintText: '00',
+                            hintStyle: TextStyle(
+                              color: INPUT_BORDER_COLOR,
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(
+                                color: ICON_GREY_COLOR,
+                                width: 1.5,
+                              )
+                            ),
+                          ),
+                          controller: TextEditingController(text: monthText),
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: 6),
+                  Text('월'),
+                  SizedBox(width: 10),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: selectDay,
+                      child: AbsorbPointer(
+                        child: TextFormField(
+                          textAlign: TextAlign.center,
+                          readOnly: true,
+                          decoration: InputDecoration(
+                            hintText: '00',
+                            hintStyle: TextStyle(
+                              color: INPUT_BORDER_COLOR,
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: ICON_GREY_COLOR,
+                                  width: 1.5,
+                              )
+                            ),
+                          ),
+                          controller: TextEditingController(text: dayText),
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: 6),
+                  Text('일'),
+                ],
+              ),
+              SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('키', style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        )),
+                        SizedBox(height: 6),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                controller: heightController,
+                                validator: validateHeight,
+                                keyboardType: TextInputType.number,
+                                textAlign: TextAlign.center,
+                                decoration: InputDecoration(
+                                  hintText: '0.0',
+                                  hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
+                                  contentPadding: EdgeInsets.symmetric(vertical: 16),
+                                  enabledBorder: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                    borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
+                                  ),
+                                  focusedBorder: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                    borderSide: BorderSide(color: MAIN_COLOR, width: 2.0),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 6),
+                            Text('cm'),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(width: 20),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('몸무게', style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500
+                        )),
+                        SizedBox(height: 6),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                controller: weightController,
+                                validator: validateWeight,
+                                keyboardType: TextInputType.number,
+                                textAlign: TextAlign.center,
+                                decoration: InputDecoration(
+                                  hintText: '0.0',
+                                  hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
+                                  contentPadding: EdgeInsets.symmetric(vertical: 16),
+                                  enabledBorder: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                    borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
+                                  ),
+                                  focusedBorder: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                    borderSide: BorderSide(color: MAIN_COLOR, width: 2.0),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 6),
+                            Text('kg'),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 20),
+              Text(
+                '성별',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              SizedBox(height: 10),
+              Row(
+                children: [
+                  for (int i = 0; i < genders.length; i++) ...[
+                    Expanded(
+                      child: SizedBox(
+                        height: 60,
+                        child: ElevatedButton(
+                          onPressed: () => setState(() {
+                            gender = genders[i];
+                          }),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: gender == genders[i]
+                                ? MAIN_COLOR.withValues(alpha: 0.13)
+                                : Theme.of(context).scaffoldBackgroundColor,
+                            foregroundColor: gender == genders[i]
+                                ? MAIN_COLOR
+                                : Colors.black54,
+                            side: BorderSide(
+                              color: gender == genders[i]
+                                  ? MAIN_COLOR
+                                  : ICON_GREY_COLOR,
+                              width: 1.5,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            elevation: 0,
+                          ).copyWith(
+                            overlayColor: WidgetStateProperty.all(Colors.transparent),
+                            splashFactory: NoSplash.splashFactory,
+                            animationDuration: Duration.zero,
+                            shadowColor: WidgetStateProperty.all(Colors.transparent),
+                          ),
+                          child: Text(
+                            genders[i],
+                            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (i != 1) SizedBox(width: 16), // 버튼 사이 간격
+                  ]
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.fromLTRB(16, 0, 16, 24),
+        child: NavigationButton(
+          text: '다음',
+          onPressed: isFormValid ? onNextPressed : null,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -8,6 +8,7 @@ import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
 import 'package:team_project_front/mypage/utils/date_picker_utils.dart';
+import 'package:team_project_front/mypage/utils/image_pick_handler.dart';
 import 'package:team_project_front/mypage/utils/validators.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
@@ -64,18 +65,6 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
     );
   }
 
-  Future<void> onPressedChangePic() async {
-    final selectedImage = await pickImageFromGallery();
-
-    if(selectedImage != null) {
-      setState(() {
-        image = selectedImage;
-      });
-    } else {
-      print('사진이 선택되지 않았습니다.');
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -101,7 +90,14 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
                     bottom: 0,
                     right: -5,
                     radius: 50,
-                    onPressedChangePic: onPressedChangePic,
+                    onPressedChangePic: () => handleImagePick(
+                      context: context,
+                      onImageSelected: (selectedImage) {
+                        setState(() {
+                          image = selectedImage;
+                        });
+                      }
+                    ),
                 ),
               ),
               SizedBox(height: 15),

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -8,6 +8,7 @@ import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
 import 'package:team_project_front/mypage/utils/date_picker_utils.dart';
+import 'package:team_project_front/mypage/utils/validators.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
 
@@ -61,24 +62,6 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
         profileInfo: profileInfo,
       )),
     );
-  }
-
-  String? validateHeight(String? value) {
-    if (value == null || value.isEmpty) return '값을 입력해주세요';
-    final parsed = double.tryParse(value);
-    if (parsed == null) return '숫자만 입력해주세요';
-    if (parsed < 0 || parsed > 200) return '0~200 사이로 입력해주세요';
-    if (!RegExp(r'^\d{1,3}(\.\d)?$').hasMatch(value)) return '소수 첫째자리까지 입력해주세요';
-    return null;
-  }
-
-  String? validateWeight(String? value) {
-    if (value == null || value.isEmpty) return '값을 입력해주세요';
-    final parsed = double.tryParse(value);
-    if (parsed == null) return '숫자만 입력해주세요';
-    if (parsed < 0 || parsed > 100) return '0~100 사이로 입력해주세요';
-    if (!RegExp(r'^\d{1,3}(\.\d)?$').hasMatch(value)) return '소수 첫째자리까지 입력해주세요';
-    return null;
   }
 
   Future<void> onPressedChangePic() async {

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/custom_input.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
@@ -242,8 +243,16 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
     return null;
   }
 
-  GestureTapCallback? onPressedChangePic() {
-    // 이미지 선택 로직 구현 예정
+  Future<void> onPressedChangePic() async {
+    final selectedImage = await pickImageFromGallery();
+
+    if(selectedImage != null) {
+      setState(() {
+        image = selectedImage;
+      });
+    } else {
+      print('사진이 선택되지 않았습니다.');
+    }
   }
 
   @override
@@ -270,6 +279,7 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
                     addImageIconSize: 18,
                     bottom: 0,
                     right: -5,
+                    radius: 50,
                     onPressedChangePic: onPressedChangePic,
                 ),
               ),

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:team_project_front/common/component/custom_input.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/colors.dart';
-import 'package:team_project_front/common/utils/image_picker_utils.dart';
+import 'package:team_project_front/mypage/component/profile_birth_input.dart';
+import 'package:team_project_front/mypage/component/profile_body_info_input.dart';
+import 'package:team_project_front/mypage/component/profile_gender_selector.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
+import 'package:team_project_front/mypage/component/profile_name_input.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
-import 'package:team_project_front/mypage/utils/date_picker_utils.dart';
 import 'package:team_project_front/mypage/utils/image_pick_handler.dart';
 import 'package:team_project_front/mypage/utils/validators.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
@@ -109,274 +110,27 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
                 ),
               ),
               SizedBox(height: 20),
-              Text(
-                '이름 / 닉네임',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              SizedBox(height: 10),
-              CustomTextFormField(
-                controller: nameController,
-                hintText: '이름 또는 애칭 입력(2-8자)',
-                validator: (val) {
-                  if (val == null || val.isEmpty) {
-                    return '이름을 입력해주세요';
-                  }
-                  if (val.length < 2 || val.length > 8) {
-                    return '2~8자 이내로 입력해주세요';
-                  }
-                  if (!RegExp(r'^[a-zA-Z가-힣]+$').hasMatch(val)) {
-                    return '한글 또는 영문만 입력 가능합니다';
-                  }
-                  return null;
-                },
+              ProfileNameInput(controller: nameController),
+              SizedBox(height: 20),
+              ProfileBirthInput(
+                yearText: yearText,
+                monthText: monthText,
+                dayText: dayText,
+                onYearSelected: (val) => setState(() => yearText = val),
+                onMonthSelected: (val) => setState(() => monthText = val),
+                onDaySelected: (val) => setState(() => dayText = val),
               ),
               SizedBox(height: 20),
-              Text(
-                '생년월일',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              SizedBox(height: 10),
-              Row(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => showYearPicker(
-                        context: context,
-                        initialYear: yearText,
-                        onSelected: (val) => setState(() => yearText = val),
-                      ),
-                      child: AbsorbPointer(
-                        child: TextFormField(
-                          textAlign: TextAlign.center,
-                          readOnly: true,
-                          decoration: InputDecoration(
-                            hintText: '0000',
-                            hintStyle: TextStyle(
-                              color: INPUT_BORDER_COLOR,
-                            ),
-                            enabledBorder: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(12),
-                              borderSide: BorderSide(
-                                color: ICON_GREY_COLOR,
-                                width: 1.5,
-                              )
-                            ),
-                          ),
-                          controller: TextEditingController(text: yearText),
-                        ),
-                      ),
-                    ),
-                  ),
-                  SizedBox(width: 6),
-                  Text('년'),
-                  SizedBox(width: 10),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => showMonthPicker(
-                        context: context,
-                        initialMonth: monthText,
-                        onSelected: (val) => setState(() => monthText = val),
-                      ),
-                      child: AbsorbPointer(
-                        child: TextFormField(
-                          textAlign: TextAlign.center,
-                          readOnly: true,
-                          decoration: InputDecoration(
-                            hintText: '00',
-                            hintStyle: TextStyle(
-                              color: INPUT_BORDER_COLOR,
-                            ),
-                            enabledBorder: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(12),
-                              borderSide: BorderSide(
-                                color: ICON_GREY_COLOR,
-                                width: 1.5,
-                              )
-                            ),
-                          ),
-                          controller: TextEditingController(text: monthText),
-                        ),
-                      ),
-                    ),
-                  ),
-                  SizedBox(width: 6),
-                  Text('월'),
-                  SizedBox(width: 10),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => showDayPicker(
-                        context: context,
-                        initialDay: dayText,
-                        onSelected: (val) => setState(() => dayText = val),
-                      ),
-                      child: AbsorbPointer(
-                        child: TextFormField(
-                          textAlign: TextAlign.center,
-                          readOnly: true,
-                          decoration: InputDecoration(
-                            hintText: '00',
-                            hintStyle: TextStyle(
-                              color: INPUT_BORDER_COLOR,
-                            ),
-                            enabledBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: BorderSide(
-                                  color: ICON_GREY_COLOR,
-                                  width: 1.5,
-                              )
-                            ),
-                          ),
-                          controller: TextEditingController(text: dayText),
-                        ),
-                      ),
-                    ),
-                  ),
-                  SizedBox(width: 6),
-                  Text('일'),
-                ],
+              ProfileBodyInfoInput(
+                heightController: heightController,
+                weightController: weightController,
+                validateHeight: validateHeight,
+                validateWeight: validateWeight,
               ),
               SizedBox(height: 20),
-              Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text('키', style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                        )),
-                        SizedBox(height: 6),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: TextFormField(
-                                controller: heightController,
-                                validator: validateHeight,
-                                keyboardType: TextInputType.number,
-                                textAlign: TextAlign.center,
-                                decoration: InputDecoration(
-                                  hintText: '0.0',
-                                  hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
-                                  contentPadding: EdgeInsets.symmetric(vertical: 16),
-                                  enabledBorder: OutlineInputBorder(
-                                    borderRadius: BorderRadius.circular(12),
-                                    borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
-                                  ),
-                                  focusedBorder: OutlineInputBorder(
-                                    borderRadius: BorderRadius.circular(12),
-                                    borderSide: BorderSide(color: MAIN_COLOR, width: 2.0),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            SizedBox(width: 6),
-                            Text('cm'),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                  SizedBox(width: 20),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text('몸무게', style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500
-                        )),
-                        SizedBox(height: 6),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: TextFormField(
-                                controller: weightController,
-                                validator: validateWeight,
-                                keyboardType: TextInputType.number,
-                                textAlign: TextAlign.center,
-                                decoration: InputDecoration(
-                                  hintText: '0.0',
-                                  hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
-                                  contentPadding: EdgeInsets.symmetric(vertical: 16),
-                                  enabledBorder: OutlineInputBorder(
-                                    borderRadius: BorderRadius.circular(12),
-                                    borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
-                                  ),
-                                  focusedBorder: OutlineInputBorder(
-                                    borderRadius: BorderRadius.circular(12),
-                                    borderSide: BorderSide(color: MAIN_COLOR, width: 2.0),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            SizedBox(width: 6),
-                            Text('kg'),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              SizedBox(height: 20),
-              Text(
-                '성별',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              SizedBox(height: 10),
-              Row(
-                children: [
-                  for (int i = 0; i < genders.length; i++) ...[
-                    Expanded(
-                      child: SizedBox(
-                        height: 60,
-                        child: ElevatedButton(
-                          onPressed: () => setState(() {
-                            gender = genders[i];
-                          }),
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: gender == genders[i]
-                                ? MAIN_COLOR.withValues(alpha: 0.13)
-                                : Theme.of(context).scaffoldBackgroundColor,
-                            foregroundColor: gender == genders[i]
-                                ? MAIN_COLOR
-                                : Colors.black54,
-                            side: BorderSide(
-                              color: gender == genders[i]
-                                  ? MAIN_COLOR
-                                  : ICON_GREY_COLOR,
-                              width: 1.5,
-                            ),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(14),
-                            ),
-                            elevation: 0,
-                          ).copyWith(
-                            overlayColor: WidgetStateProperty.all(Colors.transparent),
-                            splashFactory: NoSplash.splashFactory,
-                            animationDuration: Duration.zero,
-                            shadowColor: WidgetStateProperty.all(Colors.transparent),
-                          ),
-                          child: Text(
-                            genders[i],
-                            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
-                          ),
-                        ),
-                      ),
-                    ),
-                    if (i != 1) SizedBox(width: 16), // 버튼 사이 간격
-                  ]
-                ],
+              ProfileGenderSelector(
+                selectedGender: gender,
+                onGenderSelected: (val) => setState(() => gender = val),
               ),
             ],
           ),

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -6,60 +6,9 @@ import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
+import 'package:team_project_front/mypage/models/profile_info.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
-
-class ProfileInfo {
-  final String name;
-  final String birthYear;
-  final String birthMonth;
-  final String birthDay;
-  final double height;
-  final double weight;
-  final String gender;
-  final String? seizureHistory;
-  final List<String>? illnessList;
-  final File? image;
-  
-  ProfileInfo({
-    required this.name,
-    required this.birthYear,
-    required this.birthMonth,
-    required this.birthDay,
-    required this.height,
-    required this.weight,
-    required this.gender,
-    this.seizureHistory,
-    this.illnessList,
-    this.image,
-  });
-
-  ProfileInfo copyWith({
-    String? name,
-    String? birthYear,
-    String? birthMonth,
-    String? birthDay,
-    double? height,
-    double? weight,
-    String? gender,
-    String? seizureHistory,
-    List<String>? illnessList,
-    File? image,
-  }) {
-    return ProfileInfo(
-      name: name ?? this.name,
-      birthYear: birthYear ?? this.birthYear,
-      birthMonth: birthMonth ?? this.birthMonth,
-      birthDay: birthDay ?? this.birthDay,
-      height: height ?? this.height,
-      weight: weight ?? this.weight,
-      gender: gender ?? this.gender,
-      seizureHistory: seizureHistory ?? this.seizureHistory,
-      illnessList: illnessList ?? this.illnessList,
-      image: image ?? this.image,
-    );
-  }
-}
 
 class AddProfileScreen extends StatefulWidget {
   const AddProfileScreen({super.key});

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -7,6 +7,7 @@ import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
+import 'package:team_project_front/mypage/utils/date_picker_utils.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
 
@@ -61,118 +62,6 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
       )),
     );
   }
-
-  void selectedYear() {
-    final currentYear = DateTime.now().year;
-    final years = List.generate(100, (index) => (currentYear - index).toString());
-
-    showCupertinoModalPopup(
-      context: context,
-      builder: (_) => Container(
-        height: 250,
-        color: Colors.white,
-        child: Column(
-          children: [
-            Expanded(
-              child: CupertinoPicker(
-                scrollController: FixedExtentScrollController(
-                  initialItem: yearText != null
-                    ? years.indexOf(yearText!)
-                    : 0,
-                ),
-                itemExtent: 40,
-                onSelectedItemChanged: (index) {
-                  setState(() {
-                    yearText = years[index];
-                  });
-                },
-                children: years.map((y) => Center(child: Text('$y년'))).toList(),
-              ),
-            ),
-            CupertinoButton(
-              child: Text('확인'),
-              onPressed: () => Navigator.pop(context),
-            )
-          ],
-        ),
-      ),
-    );
-  }
-
-
-  void selectMonth() {
-    final months = List.generate(12, (i) => (i + 1).toString().padLeft(2, '0'));
-
-    showCupertinoModalPopup(
-      context: context,
-      builder: (_) => Container(
-        height: 250,
-        color: Colors.white,
-        child: Column(
-          children: [
-            Expanded(
-              child: CupertinoPicker(
-                scrollController: FixedExtentScrollController(
-                  initialItem: monthText != null
-                      ? months.indexOf(monthText!)
-                      : 0,
-                ),
-                itemExtent: 40,
-                onSelectedItemChanged: (index) {
-                  setState(() {
-                    monthText = months[index];
-                  });
-                },
-                children: months.map((m) => Center(child: Text('$m월'))).toList(),
-              ),
-            ),
-            CupertinoButton(
-              child: Text('확인'),
-              onPressed: () => Navigator.pop(context),
-            )
-          ],
-        ),
-      ),
-    );
-  }
-
-
-  void selectDay() {
-    final days = List.generate(31, (i) => (i + 1).toString().padLeft(2, '0'));
-
-    showCupertinoModalPopup(
-      context: context,
-      builder: (_) => Container(
-        height: 250,
-        color: Colors.white,
-        child: Column(
-          children: [
-            Expanded(
-              child: CupertinoPicker(
-                scrollController: FixedExtentScrollController(
-                  initialItem: dayText != null
-                      ? days.indexOf(dayText!)
-                      : 0,
-                ),
-                itemExtent: 40,
-                onSelectedItemChanged: (index) {
-                  setState(() {
-                    dayText = days[index];
-                  });
-                },
-                children: days.map((d) => Center(child: Text('$d일'))).toList(),
-              ),
-            ),
-            CupertinoButton(
-              child: Text('확인'),
-              onPressed: () => Navigator.pop(context),
-            )
-          ],
-        ),
-      ),
-    );
-  }
-
 
   String? validateHeight(String? value) {
     if (value == null || value.isEmpty) return '값을 입력해주세요';
@@ -278,7 +167,11 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
                 children: [
                   Expanded(
                     child: GestureDetector(
-                      onTap: selectedYear,
+                      onTap: () => showYearPicker(
+                        context: context,
+                        initialYear: yearText,
+                        onSelected: (val) => setState(() => yearText = val),
+                      ),
                       child: AbsorbPointer(
                         child: TextFormField(
                           textAlign: TextAlign.center,
@@ -306,7 +199,11 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
                   SizedBox(width: 10),
                   Expanded(
                     child: GestureDetector(
-                      onTap: selectMonth,
+                      onTap: () => showMonthPicker(
+                        context: context,
+                        initialMonth: monthText,
+                        onSelected: (val) => setState(() => monthText = val),
+                      ),
                       child: AbsorbPointer(
                         child: TextFormField(
                           textAlign: TextAlign.center,
@@ -334,7 +231,11 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
                   SizedBox(width: 10),
                   Expanded(
                     child: GestureDetector(
-                      onTap: selectDay,
+                      onTap: () => showDayPicker(
+                        context: context,
+                        initialDay: dayText,
+                        onSelected: (val) => setState(() => dayText = val),
+                      ),
                       child: AbsorbPointer(
                         child: TextFormField(
                           textAlign: TextAlign.center,

--- a/lib/mypage/view/add_profile_symptoms_screen.dart
+++ b/lib/mypage/view/add_profile_symptoms_screen.dart
@@ -4,7 +4,7 @@ import 'package:team_project_front/common/component/complete_dialog.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
-import 'package:team_project_front/mypage/view/add_profile_screen.dart';
+import 'package:team_project_front/mypage/models/profile_info.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
 
 class AddProfileSymptomsScreen extends StatefulWidget {

--- a/lib/mypage/view/add_profile_symptoms_screen.dart
+++ b/lib/mypage/view/add_profile_symptoms_screen.dart
@@ -1,0 +1,247 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/component/complete_dialog.dart';
+import 'package:team_project_front/common/component/navigation_button.dart';
+import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/view/root_tab.dart';
+import 'package:team_project_front/mypage/view/add_profile_screen.dart';
+import 'package:team_project_front/settings/component/custom_appbar.dart';
+
+class AddProfileSymptomsScreen extends StatefulWidget {
+  final ProfileInfo profileInfo;
+
+  const AddProfileSymptomsScreen({
+    required this.profileInfo,
+    super.key,
+  });
+
+  @override
+  State<AddProfileSymptomsScreen> createState() => _AddProfileSymptomsScreenState();
+}
+
+class _AddProfileSymptomsScreenState extends State<AddProfileSymptomsScreen> {
+
+  String? seizure;
+  Set<String> selectedIllness = {};
+
+  final List<String> seizureOptions = ['있음', '없음', '모름'];
+  final List<String> illnesses = [
+    '해당 없음', '아토피', '천식', '뇌전증',
+    '고혈압', '심장 질환', '폐 질환',
+    '간 질환', '신장 질환', '면역력 저하',
+  ];
+
+  bool get isFormValid =>
+    seizure != null &&
+    selectedIllness.isNotEmpty;
+
+  void onNextPressed() {
+    if(!isFormValid) return;
+
+    final updatedProfileInfo = widget.profileInfo.copyWith(
+      seizureHistory: seizure!,
+      illnessList: selectedIllness.toList(),
+    );
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => CompleteDialog(
+        image: widget.profileInfo.image != null
+          ? CircleAvatar(
+            radius: 40,
+            backgroundImage: FileImage(widget.profileInfo.image!),
+          )
+          : Icon(
+              Icons.account_circle,
+              size: 80,
+              color: ICON_GREY_COLOR,
+        ),
+        title: "'${widget.profileInfo.name}' 등록 완료",
+        content: "이제 아이를\n맘편해와 함께 돌봐주세요!",
+        checkText: "완료",
+        onPressedCheck: () {
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(builder: (_) => RootTab(initialTabIndex: 4)),
+            (route) => false,
+          );
+        }
+      ),
+    );
+  }
+  
+  String getDisplayText(String illness) {
+    return illness == '면역력 저하' ? '면역력\n저하' : illness;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(90),
+        child: CustomAppbar(
+          title: '프로필 등록',
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.symmetric(horizontal: 30),
+        child: Form(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                '상세 정보를 알려주시면\n좀 더 정확히 알려드릴 수 있어요',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              SizedBox(height: 10),
+              Text(
+                '상세 정보는 마이페이지에서 수정 및 입력이 가능해요',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.grey,
+                ),
+              ),
+              SizedBox(height: 20),
+              Text(
+                '열성경련 이력',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              SizedBox(height: 15),
+              Row(
+                children: [
+                  for (int i = 0; i < seizureOptions.length; i++) ...[
+                    Expanded(
+                      child: SizedBox(
+                        height: 60,
+                        child: ElevatedButton(
+                          onPressed: () => setState(() {
+                            seizure = seizureOptions[i];
+                          }),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: seizure == seizureOptions[i]
+                                ? MAIN_COLOR.withValues(alpha: 0.13)
+                                : Theme.of(context).scaffoldBackgroundColor,
+                            foregroundColor: seizure == seizureOptions[i]
+                                ? MAIN_COLOR
+                                : Colors.black54,
+                            side: BorderSide(
+                              color: seizure == seizureOptions[i]
+                                  ? MAIN_COLOR
+                                  : ICON_GREY_COLOR,
+                              width: 1.5,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            elevation: 0,
+                          ).copyWith(
+                            overlayColor: WidgetStateProperty.all(Colors.transparent),
+                            splashFactory: NoSplash.splashFactory,
+                            animationDuration: Duration.zero,
+                            shadowColor: WidgetStateProperty.all(Colors.transparent),
+                          ),
+                          child: Text(
+                            seizureOptions[i],
+                            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (i != 2) SizedBox(width: 12), // 버튼 사이 간격
+                  ]
+                ],
+              ),
+              SizedBox(height: 20),
+              Text(
+                '진단받은 질환',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              SizedBox(height: 15),
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final buttonWidth = (constraints.maxWidth - 20) / 3; // 한 줄 3개 + spacing 고려
+
+                  return Wrap(
+                    spacing: 10,
+                    runSpacing: 15,
+                    children: [
+                      for (String illness in illnesses)
+                        SizedBox(
+                          width: illness == '해당 없음'
+                              ? constraints.maxWidth // 전체 너비
+                              : buttonWidth,
+                          height: 60,
+                          child: ElevatedButton(
+                            onPressed: () {
+                              setState(() {
+                                if(illness == '해당 없음') {
+                                  selectedIllness = {'해당 없음'};
+                                } else {
+                                  selectedIllness.remove('해당 없음');
+                                  if(selectedIllness.contains(illness)) {
+                                    selectedIllness.remove(illness);
+                                  } else {
+                                    selectedIllness.add(illness);
+                                  }
+                                }
+                              });
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: selectedIllness.contains(illness)
+                                  ? MAIN_COLOR.withValues(alpha: 0.13)
+                                  : Theme.of(context).scaffoldBackgroundColor,
+                              foregroundColor: selectedIllness.contains(illness)
+                                  ? MAIN_COLOR
+                                  : Colors.black54,
+                              side: BorderSide(
+                                color: selectedIllness.contains(illness)
+                                    ? MAIN_COLOR
+                                    : ICON_GREY_COLOR,
+                                width: 1.5,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(14),
+                              ),
+                              elevation: 0,
+                            ).copyWith(
+                              overlayColor: WidgetStateProperty.all(Colors.transparent),
+                              splashFactory: NoSplash.splashFactory,
+                              animationDuration: Duration.zero,
+                              shadowColor: WidgetStateProperty.all(Colors.transparent),
+                            ),
+                            child: Text(
+                              getDisplayText(illness),
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                fontSize: 15, fontWeight: FontWeight.w700),
+                            ),
+                          ),
+                        ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          )
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.fromLTRB(16, 0, 16, 24),
+        child: NavigationButton(
+          text: '저장',
+          onPressed: isFormValid ? onNextPressed : null,
+        ),
+      )
+    );
+  }
+}

--- a/lib/mypage/view/add_profile_symptoms_screen.dart
+++ b/lib/mypage/view/add_profile_symptoms_screen.dart
@@ -3,6 +3,8 @@ import 'package:team_project_front/common/component/complete_dialog.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
+import 'package:team_project_front/mypage/component/illness_selctor.dart';
+import 'package:team_project_front/mypage/component/seizure_history_selector.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
 
@@ -105,130 +107,16 @@ class _AddProfileSymptomsScreenState extends State<AddProfileSymptomsScreen> {
                 ),
               ),
               SizedBox(height: 20),
-              Text(
-                '열성경련 이력',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              SizedBox(height: 15),
-              Row(
-                children: [
-                  for (int i = 0; i < seizureOptions.length; i++) ...[
-                    Expanded(
-                      child: SizedBox(
-                        height: 60,
-                        child: ElevatedButton(
-                          onPressed: () => setState(() {
-                            seizure = seizureOptions[i];
-                          }),
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: seizure == seizureOptions[i]
-                                ? MAIN_COLOR.withValues(alpha: 0.13)
-                                : Theme.of(context).scaffoldBackgroundColor,
-                            foregroundColor: seizure == seizureOptions[i]
-                                ? MAIN_COLOR
-                                : Colors.black54,
-                            side: BorderSide(
-                              color: seizure == seizureOptions[i]
-                                  ? MAIN_COLOR
-                                  : ICON_GREY_COLOR,
-                              width: 1.5,
-                            ),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(14),
-                            ),
-                            elevation: 0,
-                          ).copyWith(
-                            overlayColor: WidgetStateProperty.all(Colors.transparent),
-                            splashFactory: NoSplash.splashFactory,
-                            animationDuration: Duration.zero,
-                            shadowColor: WidgetStateProperty.all(Colors.transparent),
-                          ),
-                          child: Text(
-                            seizureOptions[i],
-                            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
-                          ),
-                        ),
-                      ),
-                    ),
-                    if (i != 2) SizedBox(width: 12), // 버튼 사이 간격
-                  ]
-                ],
+              SeizureHistorySelector(
+                selected: seizure,
+                options: seizureOptions,
+                onSelected: (val) => setState(() => seizure = val),
               ),
               SizedBox(height: 20),
-              Text(
-                '진단받은 질환',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              SizedBox(height: 15),
-              LayoutBuilder(
-                builder: (context, constraints) {
-                  final buttonWidth = (constraints.maxWidth - 20) / 3; // 한 줄 3개 + spacing 고려
-
-                  return Wrap(
-                    spacing: 10,
-                    runSpacing: 15,
-                    children: [
-                      for (String illness in illnesses)
-                        SizedBox(
-                          width: illness == '해당 없음'
-                              ? constraints.maxWidth // 전체 너비
-                              : buttonWidth,
-                          height: 60,
-                          child: ElevatedButton(
-                            onPressed: () {
-                              setState(() {
-                                if(illness == '해당 없음') {
-                                  selectedIllness = {'해당 없음'};
-                                } else {
-                                  selectedIllness.remove('해당 없음');
-                                  if(selectedIllness.contains(illness)) {
-                                    selectedIllness.remove(illness);
-                                  } else {
-                                    selectedIllness.add(illness);
-                                  }
-                                }
-                              });
-                            },
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: selectedIllness.contains(illness)
-                                  ? MAIN_COLOR.withValues(alpha: 0.13)
-                                  : Theme.of(context).scaffoldBackgroundColor,
-                              foregroundColor: selectedIllness.contains(illness)
-                                  ? MAIN_COLOR
-                                  : Colors.black54,
-                              side: BorderSide(
-                                color: selectedIllness.contains(illness)
-                                    ? MAIN_COLOR
-                                    : ICON_GREY_COLOR,
-                                width: 1.5,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(14),
-                              ),
-                              elevation: 0,
-                            ).copyWith(
-                              overlayColor: WidgetStateProperty.all(Colors.transparent),
-                              splashFactory: NoSplash.splashFactory,
-                              animationDuration: Duration.zero,
-                              shadowColor: WidgetStateProperty.all(Colors.transparent),
-                            ),
-                            child: Text(
-                              getDisplayText(illness),
-                              textAlign: TextAlign.center,
-                              style: TextStyle(
-                                fontSize: 15, fontWeight: FontWeight.w700),
-                            ),
-                          ),
-                        ),
-                    ],
-                  );
-                },
+              IllnessSelector(
+                illnesses: illnesses,
+                selectedIllnesses: selectedIllness,
+                onSelectionChanged: (newSet) => setState(() => selectedIllness = newSet),
               ),
             ],
           )

--- a/lib/mypage/view/add_profile_symptoms_screen.dart
+++ b/lib/mypage/view/add_profile_symptoms_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/complete_dialog.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/view/add_profile_screen.dart';
 
@@ -15,6 +17,8 @@ class _MyScreenState extends State<MyScreen> {
   File? image;
   List<String> members = ['김준형', '최강민'];
 
+  final ImagePicker picker = ImagePicker();
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -22,7 +26,7 @@ class _MyScreenState extends State<MyScreen> {
         SizedBox(height: 24),
         MyProfile(
           image: image,
-          onPressedChangePic: () {},
+          onPressedChangePic: onPressedChangePic,
           onPressedChangeProfile: () {},
         ),
         SizedBox(height: 36),
@@ -32,6 +36,18 @@ class _MyScreenState extends State<MyScreen> {
         )
       ],
     );
+  }
+
+  Future<void> onPressedChangePic() async {
+    final selectedImage = await pickImageFromGallery();
+
+    if(selectedImage != null) {
+      setState(() {
+        image = selectedImage;
+      });
+    } else {
+      print('사진이 선택되지 않았습니다.');
+    }
   }
   
   void onPressedAdd() {
@@ -63,6 +79,7 @@ class MyProfile extends StatelessWidget {
             addImageIconSize: 24,
             bottom: 0,
             right: 4,
+            radius: 70,
             onPressedChangePic: onPressedChangePic
         ),
         SizedBox(height: 12),

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
+import 'package:team_project_front/mypage/view/add_profile_screen.dart';
 
 class MyScreen extends StatefulWidget {
   const MyScreen({super.key});
@@ -26,9 +28,15 @@ class _MyScreenState extends State<MyScreen> {
         SizedBox(height: 36),
         FamilyProfile(
             members: members,
-            onPressedAdd: () {},
+            onPressedAdd: onPressedAdd,
         )
       ],
+    );
+  }
+  
+  void onPressedAdd() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (context) => AddProfileScreen())
     );
   }
 }
@@ -49,36 +57,13 @@ class MyProfile extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Stack(
-          children: [
-            image != null ? CircleAvatar(
-              radius: 70,
-              backgroundColor: Colors.white,
-              backgroundImage: image != null ? FileImage(image!) : null,
-            ) : Icon(
-              Icons.account_circle,
-              size: 140,
-              color: ICON_GREY_COLOR,
-            ),
-            Positioned(
-              bottom: 0,
-              right: 4,
-              child: GestureDetector(
-                onTap: onPressedChangePic,
-                child: Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: Colors.grey[50],
-                    shape: BoxShape.circle,
-                  ),
-                  child: Icon(
-                    Icons.add_a_photo,
-                    color: ICON_GREY_COLOR,
-                  ),
-                ),
-              ),
-            ),
-          ],
+        ProfileImageWithAddIcon(
+            image: image,
+            profileIconSize: 140,
+            addImageIconSize: 24,
+            bottom: 0,
+            right: 4,
+            onPressedChangePic: onPressedChangePic
         ),
         SizedBox(height: 12),
         Text(

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:team_project_front/common/const/colors.dart';
-import 'package:team_project_front/common/utils/image_picker_utils.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
+import 'package:team_project_front/mypage/utils/image_pick_handler.dart';
 import 'package:team_project_front/mypage/view/add_profile_screen.dart';
 
 class MyScreen extends StatefulWidget {
@@ -26,7 +26,14 @@ class _MyScreenState extends State<MyScreen> {
         SizedBox(height: 24),
         MyProfile(
           image: image,
-          onPressedChangePic: onPressedChangePic,
+          onPressedChangePic: () => handleImagePick(
+            context: context,
+            onImageSelected: (selectedImage) {
+              setState(() {
+                image = selectedImage;
+              });
+            },
+          ),
           onPressedChangeProfile: () {},
         ),
         SizedBox(height: 36),
@@ -36,18 +43,6 @@ class _MyScreenState extends State<MyScreen> {
         )
       ],
     );
-  }
-
-  Future<void> onPressedChangePic() async {
-    final selectedImage = await pickImageFromGallery();
-
-    if(selectedImage != null) {
-      setState(() {
-        image = selectedImage;
-      });
-    } else {
-      print('사진이 선택되지 않았습니다.');
-    }
   }
   
   void onPressedAdd() {

--- a/lib/settings/component/custom_appbar.dart
+++ b/lib/settings/component/custom_appbar.dart
@@ -24,13 +24,14 @@ class CustomAppbar extends StatelessWidget {
             },
             icon: Icon(Icons.arrow_back_ios_new),
           ),
-          title: Text(title),
-          centerTitle: true,
-          titleTextStyle: TextStyle(
-            fontSize: 25,
-            color: Colors.black,
-            fontWeight: FontWeight.w900,
+          title: Text(
+            title,
+            style: TextStyle(
+              fontSize: 25,
+              fontWeight: FontWeight.w900,
+            ),
           ),
+          centerTitle: true,
         ),
       ],
     );

--- a/lib/settings/view/settings_screen.dart
+++ b/lib/settings/view/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:team_project_front/common/component/yes_or_no_dialog.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
 import 'package:team_project_front/settings/view/notification_settings_screen.dart';
@@ -13,8 +14,8 @@ class SettingsScreen extends StatelessWidget {
       {'title': '알림 설정', 'onTap': () => onPressedNotification(context)},
       {'title': '약관', 'onTap': () => onPressedTerms(context)},
       {'title': '버전 정보', 'trailing': '1.0.0', 'onTap': null},
-      {'title': '로그아웃', 'onTap': () {}},
-      {'title': '회원 탈퇴', 'onTap': () {}},
+      {'title': '로그아웃', 'onTap': () => onPressedLogout(context)},
+      {'title': '회원 탈퇴', 'onTap': () => onPressedWithdraw(context)},
     ];
 
     return Scaffold(
@@ -39,6 +40,39 @@ class SettingsScreen extends StatelessWidget {
   void onPressedNotification(BuildContext context) {
     Navigator.of(context).push(
       MaterialPageRoute(builder: (context) => NotificationSettingsScreen())
+    );
+  }
+
+  void onPressedLogout(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => YesOrNoDialog(
+        title: '로그아웃',
+        content: '정말 로그아웃 하시겠습니까?',
+        onPressedYes: () {
+          // 로그아웃 처리 로직
+        },
+        yesText: '예',
+        noText: '아니오',
+      ),
+    );
+  }
+
+  void onPressedWithdraw(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => YesOrNoDialog(
+        title: '회원 탈퇴',
+        content:
+          '회원 탈퇴 시 기록하신 모든 데이터가\n'
+          '삭제되어 복구가 불가능합니다.\n'
+          '정말 탈퇴하시겠습니까?',
+        onPressedYes: () {
+          // 회원 탈퇴 처리 로직
+        },
+        yesText: '예',
+        noText: '아니오',
+      ),
     );
   }
 }

--- a/lib/settings/view/terms_screen.dart
+++ b/lib/settings/view/terms_screen.dart
@@ -10,6 +10,7 @@ class TermsScreen extends StatelessWidget {
     final List<Map<String, dynamic>> settingsItems = [
       {'title': '서비스 이용약관', 'onTap': () {}},
       {'title': '개인정보 처리방침', 'onTap': () => {}},
+      {'title': '민감정보 처리방침', 'onTap': () {}},
       {'title': '위치정보 서비스 이용약관', 'onTap': () {}},
     ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,10 +87,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -212,10 +212,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
 sdks:
   dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -65,6 +73,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "8c9250b2bd2d8d4268e39c82543bacbaca0fda7d29e0728c3c4bbb7c820fd711"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -78,11 +118,104 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+23"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   leak_tracker:
     dependency: transitive
     description:
@@ -139,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -147,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -200,6 +349,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -216,6 +373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.7.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   email_validator: ^3.0.0
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 로그아웃 및 회원 탈퇴 기능에 공통으로 사용되는 YesOrNoDialog 모달 컴포넌트 생성
- 설정의 약관 페이지 "민감정보 처리방침" 항목 추가
- 설정의 AppBar title의 굵기 설정 정상 구현
- root_tab.dart의 앱바 컴포넌트 분리 => common/component/custom_appbar_root_tab.dart
- 프로필 등록 UI 구현
- image_picker 라이브러리 추가 및 갤러리에서 사진 가져오는 기능 구현  => **pub get 해주세요**
- ProfileInfo 클래스를 별도의 파일로 분리하여 관리 용이성 향상
- AddProfileScreen 내 이름/생년월일/신체/성별 입력 컴포넌트화
- AddProfileSymptomsScreen 내 주요 위젯 컴포넌트화


  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/6eb356d4-a8e2-41f6-a6c8-6e85c55df9e6)
![image](https://github.com/user-attachments/assets/65dd69a6-019e-4983-846a-b09aeb5bb424)
![image](https://github.com/user-attachments/assets/a0061a60-ba06-42ed-ba75-cf88e385b1f5)


<br/>


## ➕ 이슈 링크

- [frontend #16 ]

<br/>
