### PR TITLE
✨ [Feat] 캘린더 기본 레이아웃 UI 및 캘린더 일정 추가, 삭제 등 일정 관련 UI 구현

### DIFF
--- a/lib/calendar/component/calendar.dart
+++ b/lib/calendar/component/calendar.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class Calendar extends StatelessWidget {
+  final DateTime focusedDay;
+  final bool Function(DateTime)? selectedDayPredicate;
+  final void Function(DateTime selectedDay, DateTime focusedDay)? onDaySelected;
+
+  const Calendar({
+    super.key,
+    required this.focusedDay,
+    required this.selectedDayPredicate,
+    required this.onDaySelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final defaultBoxDecoration = BoxDecoration(
+      borderRadius: BorderRadius.circular(6),
+      border: Border.all(
+        color: Colors.grey[200]!,
+        width: 1,
+      ),
+    );
+
+    final defaultTextStyle = TextStyle(
+      color: Colors.grey[600],
+      fontWeight: FontWeight.w700,
+    );
+
+    return TableCalendar(
+      locale: 'ko_KR',
+      focusedDay: focusedDay,
+      firstDay: DateTime(2025),
+      lastDay: DateTime(2100),
+      headerStyle: HeaderStyle(
+        formatButtonVisible: false,
+        titleCentered: true,
+        titleTextStyle: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+      calendarStyle: CalendarStyle(
+        isTodayHighlighted: true,
+        defaultDecoration: defaultBoxDecoration,
+        weekendDecoration: defaultBoxDecoration,
+        selectedDecoration: defaultBoxDecoration.copyWith(
+          border: Border.all(color: MAIN_COLOR),
+        ),
+        todayDecoration: defaultBoxDecoration.copyWith(
+          color: MAIN_COLOR,
+        ),
+        outsideDecoration: defaultBoxDecoration.copyWith(
+          border: Border.all(color: Colors.transparent),
+        ),
+        defaultTextStyle: defaultTextStyle,
+        weekendTextStyle: defaultTextStyle,
+        selectedTextStyle: defaultTextStyle.copyWith(
+          color: MAIN_COLOR,
+        ),
+      ),
+      selectedDayPredicate: selectedDayPredicate,
+      onDaySelected: onDaySelected,
+    );
+  }
+}

--- a/lib/calendar/component/calendar.dart
+++ b/lib/calendar/component/calendar.dart
@@ -6,12 +6,14 @@ class Calendar extends StatelessWidget {
   final DateTime focusedDay;
   final bool Function(DateTime)? selectedDayPredicate;
   final void Function(DateTime selectedDay, DateTime focusedDay)? onDaySelected;
+  final List<Object> Function(DateTime day)? eventLoader;
 
   const Calendar({
     super.key,
     required this.focusedDay,
     required this.selectedDayPredicate,
     required this.onDaySelected,
+    this.eventLoader,
   });
 
   @override
@@ -63,6 +65,29 @@ class Calendar extends StatelessWidget {
       ),
       selectedDayPredicate: selectedDayPredicate,
       onDaySelected: onDaySelected,
+      eventLoader: eventLoader,
+      calendarBuilders: CalendarBuilders(
+        markerBuilder: (context, date, events) {
+          if(events.isEmpty) return SizedBox();
+
+          final limitedEvents = events.take(3).toList();
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: List.generate(
+              limitedEvents.length,
+              (index) => Container(
+                margin: EdgeInsets.symmetric(horizontal: 1),
+                width: 6,
+                height: 6,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: MAIN_COLOR,
+                ),
+              ),
+            ),
+          );
+        }
+      ),
     );
   }
 }

--- a/lib/calendar/component/custom_text_input.dart
+++ b/lib/calendar/component/custom_text_input.dart
@@ -6,6 +6,7 @@ class CustomTextInput extends StatelessWidget {
   final String hintText;
   final TextEditingController controller;
   final int maxLines;
+  final String? Function(String?)? validator;
 
   const CustomTextInput({
     super.key,
@@ -13,6 +14,7 @@ class CustomTextInput extends StatelessWidget {
     required this.hintText,
     required this.controller,
     this.maxLines = 1,
+    this.validator,
   });
 
   @override
@@ -31,6 +33,7 @@ class CustomTextInput extends StatelessWidget {
         TextFormField(
           controller: controller,
           maxLines: maxLines,
+          validator: validator,
           decoration: InputDecoration(
             hintText: hintText,
             hintStyle: TextStyle(

--- a/lib/calendar/component/custom_text_input.dart
+++ b/lib/calendar/component/custom_text_input.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class CustomTextInput extends StatelessWidget {
+  final String label;
+  final String hintText;
+  final TextEditingController controller;
+  final int maxLines;
+
+  const CustomTextInput({
+    super.key,
+    required this.label,
+    required this.hintText,
+    required this.controller,
+    this.maxLines = 1,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontWeight: FontWeight.w700,
+            fontSize: 18,
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          controller: controller,
+          maxLines: maxLines,
+          decoration: InputDecoration(
+            hintText: hintText,
+            hintStyle: TextStyle(
+              color: INPUT_BORDER_COLOR,
+              fontWeight: FontWeight.w500,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(20),
+              borderSide: BorderSide(color: MAIN_COLOR, width: 1.5),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(20),
+              borderSide: BorderSide(
+                color: MAIN_COLOR.withValues(alpha: 0.5),
+                width: 4,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/calendar/component/plan_add.dart
+++ b/lib/calendar/component/plan_add.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/calendar/component/custom_text_input.dart';
+import 'package:team_project_front/common/component/navigation_button.dart';
+
+class PlanAdd extends StatelessWidget {
+  final TextEditingController titleController;
+  final TextEditingController contentController;
+  final VoidCallback onPressed;
+
+  const PlanAdd({
+    super.key,
+    required this.titleController,
+    required this.contentController,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(25.0),
+      child: SizedBox(
+        height: 600,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CustomTextInput(
+              label: '제목',
+              hintText: '제목을 입력해주세요.',
+              controller: titleController,
+            ),
+            SizedBox(height: 12),
+            CustomTextInput(
+              label: '내용',
+              hintText: '내용을 입력해주세요.',
+              controller: contentController,
+              maxLines: 7,
+            ),
+            SizedBox(height: 32),
+            NavigationButton(
+              text: '추가',
+              onPressed: onPressed,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/calendar/component/plan_add.dart
+++ b/lib/calendar/component/plan_add.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:team_project_front/calendar/component/custom_text_input.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 
-class PlanAdd extends StatelessWidget {
+class PlanAdd extends StatefulWidget {
   final TextEditingController titleController;
   final TextEditingController contentController;
   final VoidCallback onPressed;
@@ -15,34 +15,86 @@ class PlanAdd extends StatelessWidget {
   });
 
   @override
+  State<PlanAdd> createState() => _PlanAddState();
+}
+
+class _PlanAddState extends State<PlanAdd> {
+  final _formKey = GlobalKey<FormState>();
+  bool isFormValid = false;
+
+  void _validateForm() {
+    final valid = _formKey.currentState?.validate() ?? false;
+    if (valid != isFormValid) {
+      setState(() {
+        isFormValid = valid;
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.titleController.addListener(_validateForm);
+    widget.contentController.addListener(_validateForm);
+  }
+
+  @override
+  void dispose() {
+    widget.titleController.removeListener(_validateForm);
+    widget.contentController.removeListener(_validateForm);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(25.0),
-      child: SizedBox(
-        height: 600,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            CustomTextInput(
-              label: '제목',
-              hintText: '제목을 입력해주세요.',
-              controller: titleController,
-            ),
-            SizedBox(height: 12),
-            CustomTextInput(
-              label: '내용',
-              hintText: '내용을 입력해주세요.',
-              controller: contentController,
-              maxLines: 7,
-            ),
-            SizedBox(height: 32),
-            NavigationButton(
-              text: '추가',
-              onPressed: onPressed,
-            ),
-          ],
+      padding: EdgeInsets.only(
+        left: 25,
+        right: 25,
+        top: 25,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 25,
+      ),
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          onChanged: _validateForm,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CustomTextInput(
+                label: '제목',
+                hintText: '제목을 입력해주세요.',
+                controller: widget.titleController,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '제목은 필수 입력 항목입니다.';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: 12),
+              CustomTextInput(
+                label: '내용',
+                hintText: '내용을 입력해주세요.',
+                controller: widget.contentController,
+                maxLines: 7,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '내용을 입력해주세요.';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: 28),
+              NavigationButton(
+                text: '추가',
+                onPressed: isFormValid ? widget.onPressed : null,
+              ),
+            ],
+          ),
         ),
       ),
     );
+    ;
   }
 }

--- a/lib/calendar/component/plan_add.dart
+++ b/lib/calendar/component/plan_add.dart
@@ -7,12 +7,14 @@ class PlanAdd extends StatefulWidget {
   final TextEditingController titleController;
   final TextEditingController contentController;
   final DateTime selectedDay;
+  final int? existingId;
 
   const PlanAdd({
     super.key,
     required this.titleController,
     required this.contentController,
     required this.selectedDay,
+    this.existingId,
   });
 
   @override
@@ -34,7 +36,7 @@ class _PlanAddState extends State<PlanAdd> {
 
   void onPressed () {
     final plan = Plan(
-      id: 999,
+      id: widget.existingId ?? DateTime.now().millisecondsSinceEpoch,
       title: widget.titleController.text,
       content: widget.contentController.text,
       date: widget.selectedDay,
@@ -102,7 +104,7 @@ class _PlanAddState extends State<PlanAdd> {
               ),
               SizedBox(height: 28),
               NavigationButton(
-                text: '추가',
+                text: '저장',
                 onPressed: isFormValid ? onPressed : null,
               ),
             ],

--- a/lib/calendar/component/plan_add.dart
+++ b/lib/calendar/component/plan_add.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:team_project_front/calendar/component/custom_text_input.dart';
+import 'package:team_project_front/calendar/model/plan.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 
 class PlanAdd extends StatefulWidget {
   final TextEditingController titleController;
   final TextEditingController contentController;
-  final VoidCallback onPressed;
+  final DateTime selectedDay;
 
   const PlanAdd({
     super.key,
     required this.titleController,
     required this.contentController,
-    required this.onPressed,
+    required this.selectedDay,
   });
 
   @override
@@ -29,6 +30,20 @@ class _PlanAddState extends State<PlanAdd> {
         isFormValid = valid;
       });
     }
+  }
+
+  void onPressed () {
+    final plan = Plan(
+      id: 999,
+      title: widget.titleController.text,
+      content: widget.contentController.text,
+      date: widget.selectedDay,
+      createdAt: DateTime.now().toUtc(),
+    );
+
+    Navigator.of(context).pop(
+      plan,
+    );
   }
 
   @override
@@ -88,7 +103,7 @@ class _PlanAddState extends State<PlanAdd> {
               SizedBox(height: 28),
               NavigationButton(
                 text: '추가',
-                onPressed: isFormValid ? widget.onPressed : null,
+                onPressed: isFormValid ? onPressed : null,
               ),
             ],
           ),

--- a/lib/calendar/component/plan_banner.dart
+++ b/lib/calendar/component/plan_banner.dart
@@ -3,11 +3,9 @@ import 'package:team_project_front/common/const/colors.dart';
 
 class PlanBanner extends StatelessWidget {
   final DateTime selectedDay;
-  final int taskCount;
 
   const PlanBanner({
     required this.selectedDay,
-    required this.taskCount,
     super.key,
   });
 
@@ -22,13 +20,6 @@ class PlanBanner extends StatelessWidget {
           children: [
             Text(
               '${selectedDay.year}년 ${selectedDay.month}월 ${selectedDay.day}일',
-              style: TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            Text(
-              '$taskCount개',
               style: TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.w700,

--- a/lib/calendar/component/plan_banner.dart
+++ b/lib/calendar/component/plan_banner.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class PlanBanner extends StatelessWidget {
+  final DateTime selectedDay;
+  final int taskCount;
+
+  const PlanBanner({
+    required this.selectedDay,
+    required this.taskCount,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: MAIN_COLOR,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '${selectedDay.year}년 ${selectedDay.month}월 ${selectedDay.day}일',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              '$taskCount개',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/calendar/component/plan_card.dart
+++ b/lib/calendar/component/plan_card.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class PlanCard extends StatelessWidget {
+  final String title;
+  final String content;
+  final VoidCallback? onEditPressed;
+
+  const PlanCard({
+    super.key,
+    required this.title,
+    required this.content,
+    this.onEditPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: Colors.grey[200]!),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 4,
+            height: 48,
+            margin: const EdgeInsets.only(right: 12),
+            decoration: BoxDecoration(
+              color: MAIN_COLOR,
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  content,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.grey[600],
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: onEditPressed ?? () {},
+            icon: Icon(
+              Icons.edit_calendar,
+              color: MAIN_COLOR,
+              size: 28,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/calendar/component/plan_card.dart
+++ b/lib/calendar/component/plan_card.dart
@@ -16,7 +16,6 @@ class PlanCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,

--- a/lib/calendar/component/plan_card.dart
+++ b/lib/calendar/component/plan_card.dart
@@ -58,7 +58,7 @@ class PlanCard extends StatelessWidget {
             ),
           ),
           IconButton(
-            onPressed: onEditPressed ?? () {},
+            onPressed: onEditPressed,
             icon: Icon(
               Icons.edit_calendar,
               color: MAIN_COLOR,

--- a/lib/calendar/model/plan.dart
+++ b/lib/calendar/model/plan.dart
@@ -1,0 +1,20 @@
+class Plan {
+  // 식별 가능한 ID
+  final int id;
+  // 제목
+  final String title;
+  // 내용
+  final String content;
+  // 날짜
+  final DateTime date;
+  // 일정 생성날짜시간
+  final DateTime createdAt;
+
+  Plan({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.date,
+    required this.createdAt,
+  });
+}

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:table_calendar/table_calendar.dart';
-import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/calendar/component/calendar.dart';
+import 'package:team_project_front/calendar/component/plan_banner.dart';
+import 'package:team_project_front/calendar/component/plan_card.dart';
 
 class CalendarScreen extends StatefulWidget {
   const CalendarScreen({super.key});
@@ -10,7 +11,11 @@ class CalendarScreen extends StatefulWidget {
 }
 
 class _CalendarScreenState extends State<CalendarScreen> {
-  DateTime? selectedDay;
+  DateTime? selectedDay = DateTime.utc(
+    DateTime.now().year,
+    DateTime.now().month,
+    DateTime.now().day,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -28,53 +33,45 @@ class _CalendarScreenState extends State<CalendarScreen> {
     );
 
     return Scaffold(
-      body: TableCalendar(
-        locale: 'ko_KR',
-        focusedDay: DateTime.now(),
-        firstDay: DateTime(2025),
-        lastDay: DateTime(2100),
-        headerStyle: HeaderStyle(
-          formatButtonVisible: false,
-          titleCentered: true,
-          titleTextStyle: TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.w900,
+      body: Column(
+        children: [
+          Calendar(
+            focusedDay: DateTime.now(),
+            selectedDayPredicate: selectedDayPredicate,
+            onDaySelected: onDaySelected,
           ),
-        ),
-        calendarStyle: CalendarStyle(
-          isTodayHighlighted: true,
-          defaultDecoration: defaultBoxDecoration,
-          weekendDecoration: defaultBoxDecoration,
-          selectedDecoration: defaultBoxDecoration.copyWith(
-            border: Border.all(
-              color: MAIN_COLOR,
-            )
+          SizedBox(height: 16),
+          PlanBanner(
+            selectedDay: selectedDay!,
+            taskCount: 0,
           ),
-          todayDecoration: defaultBoxDecoration.copyWith(
-            color: MAIN_COLOR,
+          Expanded(
+            child: ListView(
+              children: [
+                PlanCard(
+                  title: 'Voghair 응암역 2호점',
+                  content: '10시 ~ 10:30, 서울특별시 은평구 은평로 41...',
+                ),
+              ],
+            ),
           ),
-          outsideDecoration: defaultBoxDecoration.copyWith(
-            border: Border.all(
-              color: Colors.transparent,
-            )
-          ),
-          defaultTextStyle: defaultTextStyle,
-          weekendTextStyle: defaultTextStyle,
-          selectedTextStyle: defaultTextStyle.copyWith(
-            color: MAIN_COLOR,
-          ),
-        ),
-        selectedDayPredicate: (DateTime date) {
-          if (selectedDay == null) return false;
 
-          return date.isAtSameMomentAs(selectedDay!);
-        },
-        onDaySelected: (DateTime selectedDay, DateTime focusedDay) {
-          setState(() {
-            this.selectedDay = selectedDay;
-          });
-        },
+        ],
       ),
     );
+  }
+
+  void onDaySelected(DateTime selectedDay, DateTime focusedDay) {
+    setState(() {
+      this.selectedDay = selectedDay;
+    });
+  }
+
+  bool selectedDayPredicate(DateTime date) {
+    if(selectedDay == null) {
+      return false;
+    }
+
+    return date.isAtSameMomentAs(selectedDay!);
   }
 }

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -3,6 +3,7 @@ import 'package:team_project_front/calendar/component/calendar.dart';
 import 'package:team_project_front/calendar/component/plan_add.dart';
 import 'package:team_project_front/calendar/component/plan_banner.dart';
 import 'package:team_project_front/calendar/component/plan_card.dart';
+import 'package:team_project_front/calendar/model/plan.dart';
 import 'package:team_project_front/common/const/colors.dart';
 
 class CalendarScreen extends StatefulWidget {
@@ -21,6 +22,25 @@ class _CalendarScreenState extends State<CalendarScreen> {
     DateTime.now().month,
     DateTime.now().day,
   );
+
+  Map<DateTime, List<Plan>> plans = {
+    DateTime.utc(2025, 6, 30) : [
+      Plan(
+        id: 1,
+        title: 'Voghair 응암역 2호점',
+        content: '10시 ~ 10:30, 서울특별시 은평구 은평로 41...',
+        date: DateTime.utc(2025, 6, 30),
+        createdAt: DateTime.now().toUtc(),
+      ),
+      Plan(
+        id: 2,
+        title: '상명대학교',
+        content: '졸프 회의 및 교수님 면담',
+        date: DateTime.utc(2025, 6, 30),
+        createdAt: DateTime.now().toUtc(),
+      )
+    ]
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -63,12 +83,12 @@ class _CalendarScreenState extends State<CalendarScreen> {
           ),
           Expanded(
             child: ListView(
-              children: [
+              children: plans.containsKey(selectedDay) ? plans[selectedDay]!.map((e) =>
                 PlanCard(
-                  title: 'Voghair 응암역 2호점',
-                  content: '10시 ~ 10:30, 서울특별시 은평구 은평로 41...',
-                ),
-              ],
+                  title: e.title,
+                  content: e.content,
+                )
+              ).toList() : [],
             ),
           ),
         ],

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:team_project_front/calendar/component/calendar.dart';
+import 'package:team_project_front/calendar/component/plan_add.dart';
 import 'package:team_project_front/calendar/component/plan_banner.dart';
 import 'package:team_project_front/calendar/component/plan_card.dart';
+import 'package:team_project_front/common/const/colors.dart';
 
 class CalendarScreen extends StatefulWidget {
   const CalendarScreen({super.key});
@@ -11,6 +13,9 @@ class CalendarScreen extends StatefulWidget {
 }
 
 class _CalendarScreenState extends State<CalendarScreen> {
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController contentController = TextEditingController();
+
   DateTime? selectedDay = DateTime.utc(
     DateTime.now().year,
     DateTime.now().month,
@@ -19,20 +24,31 @@ class _CalendarScreenState extends State<CalendarScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final defaultBoxDecoration = BoxDecoration(
-      borderRadius: BorderRadius.circular(6),
-      border: Border.all(
-        color: Colors.grey[200]!,
-        width: 1,
-      )
-    );
-
-    final defaultTextStyle = TextStyle(
-      color: Colors.grey[600],
-      fontWeight: FontWeight.w700,
-    );
-
     return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        highlightElevation: 0,
+        onPressed: () {
+          showModalBottomSheet(
+            context: context,
+            builder: (_) {
+              return PlanAdd(
+                titleController: titleController,
+                contentController: contentController,
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              );
+            },
+          );
+        },
+        child: Icon(
+          size: 40,
+          Icons.add_circle,
+          color: MAIN_COLOR,
+        ),
+      ),
       body: Column(
         children: [
           Calendar(
@@ -55,7 +71,6 @@ class _CalendarScreenState extends State<CalendarScreen> {
               ],
             ),
           ),
-
         ],
       ),
     );

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -49,20 +49,33 @@ class _CalendarScreenState extends State<CalendarScreen> {
         elevation: 0,
         backgroundColor: Colors.transparent,
         highlightElevation: 0,
-        onPressed: () {
-          showModalBottomSheet(
+        onPressed: () async {
+          final resp = await showModalBottomSheet<Plan>(
             context: context,
             isScrollControlled: true,
             builder: (_) {
               return PlanAdd(
                 titleController: titleController,
                 contentController: contentController,
-                onPressed: () {
-                  Navigator.pop(context);
-                },
+                selectedDay: selectedDay!,
               );
             },
           );
+
+          if(resp == null) {
+            return;
+          }
+
+          setState(() {
+            plans = {
+              ...plans,
+              resp.date: [
+                if(plans.containsKey(resp.date))
+                  ...plans[resp.date]!,
+                resp,
+              ]
+            };
+          });
         },
         child: Icon(
           size: 40,

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -29,6 +29,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
 
     return Scaffold(
       body: TableCalendar(
+        locale: 'ko_KR',
         focusedDay: DateTime.now(),
         firstDay: DateTime(2025),
         lastDay: DateTime(2100),

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -23,6 +23,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
     DateTime.now().day,
   );
 
+  DateTime focusedDay = DateTime.now();
+
   Map<DateTime, List<Plan>> plans = {
     DateTime.utc(2025, 6, 30) : [
       Plan(
@@ -86,9 +88,13 @@ class _CalendarScreenState extends State<CalendarScreen> {
       body: Column(
         children: [
           Calendar(
-            focusedDay: DateTime.now(),
+            focusedDay: focusedDay,
             selectedDayPredicate: selectedDayPredicate,
             onDaySelected: onDaySelected,
+            eventLoader: (day) {
+              final normalizedDay = DateTime.utc(day.year, day.month, day.day);
+              return plans[normalizedDay] ?? [];
+            },
           ),
           SizedBox(height: 16),
           PlanBanner(
@@ -148,9 +154,10 @@ class _CalendarScreenState extends State<CalendarScreen> {
     );
   }
 
-  void onDaySelected(DateTime selectedDay, DateTime focusedDay) {
+  void onDaySelected(DateTime selectedDay, DateTime newFocusedDay) {
     setState(() {
       this.selectedDay = selectedDay;
+      focusedDay = newFocusedDay;
     });
   }
 

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -55,8 +55,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
             isScrollControlled: true,
             builder: (_) {
               return PlanAdd(
-                titleController: titleController,
-                contentController: contentController,
+                titleController: titleController..clear(),
+                contentController: contentController..clear(),
                 selectedDay: selectedDay!,
               );
             },
@@ -93,7 +93,6 @@ class _CalendarScreenState extends State<CalendarScreen> {
           SizedBox(height: 16),
           PlanBanner(
             selectedDay: selectedDay!,
-            taskCount: 0,
           ),
           Expanded(
             child: ListView.builder(
@@ -114,6 +113,31 @@ class _CalendarScreenState extends State<CalendarScreen> {
                   child: PlanCard(
                     title: planModel.title,
                     content: planModel.content,
+                    onEditPressed: () async {
+                      titleController.text = planModel.title;
+                      contentController.text = planModel.content;
+
+                      final editedPlan = await showModalBottomSheet<Plan>(
+                        context: context,
+                        isScrollControlled: true,
+                        builder: (_) {
+                          return PlanAdd(
+                            titleController: titleController..text = planModel.title,
+                            contentController: contentController..text = planModel.content,
+                            selectedDay: selectedDay!,
+                            existingId: planModel.id,
+                          );
+                        },
+                      );
+
+                      if (editedPlan != null) {
+                        setState(() {
+                          final list = List<Plan>.from(plans[selectedDay]!);
+                          list[index] = editedPlan;
+                          plans[selectedDay!] = list;
+                        });
+                      }
+                    },
                   ),
                 );
               },

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -102,9 +102,19 @@ class _CalendarScreenState extends State<CalendarScreen> {
                 final selectedPlans = plans[selectedDay]!;
                 final planModel = selectedPlans[index];
 
-                return PlanCard(
-                  title: planModel.title,
-                  content: planModel.content,
+                return Dismissible(
+                  key: ValueKey(planModel.id),
+                  direction: DismissDirection.endToStart,
+                  onDismissed: (_) => {
+                    setState(() {
+                      plans[selectedDay]!.removeAt(index);
+                    }),
+                    // db에서 삭제하는 로직 구현 예정
+                  },
+                  child: PlanCard(
+                    title: planModel.title,
+                    content: planModel.content,
+                  ),
                 );
               },
             ),

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -52,6 +52,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
         onPressed: () {
           showModalBottomSheet(
             context: context,
+            isScrollControlled: true,
             builder: (_) {
               return PlanAdd(
                 titleController: titleController,
@@ -82,13 +83,17 @@ class _CalendarScreenState extends State<CalendarScreen> {
             taskCount: 0,
           ),
           Expanded(
-            child: ListView(
-              children: plans.containsKey(selectedDay) ? plans[selectedDay]!.map((e) =>
-                PlanCard(
-                  title: e.title,
-                  content: e.content,
-                )
-              ).toList() : [],
+            child: ListView.builder(
+              itemCount: plans.containsKey(selectedDay) ? plans[selectedDay]!.length : 0,
+              itemBuilder: (BuildContext context, int index) {
+                final selectedPlans = plans[selectedDay]!;
+                final planModel = selectedPlans[index];
+
+                return PlanCard(
+                  title: planModel.title,
+                  content: planModel.content,
+                );
+              },
             ),
           ),
         ],

--- a/lib/calendar/view/calendar_screen.dart
+++ b/lib/calendar/view/calendar_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:team_project_front/common/const/colors.dart';
+
+class CalendarScreen extends StatefulWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  State<CalendarScreen> createState() => _CalendarScreenState();
+}
+
+class _CalendarScreenState extends State<CalendarScreen> {
+  DateTime? selectedDay;
+
+  @override
+  Widget build(BuildContext context) {
+    final defaultBoxDecoration = BoxDecoration(
+      borderRadius: BorderRadius.circular(6),
+      border: Border.all(
+        color: Colors.grey[200]!,
+        width: 1,
+      )
+    );
+
+    final defaultTextStyle = TextStyle(
+      color: Colors.grey[600],
+      fontWeight: FontWeight.w700,
+    );
+
+    return Scaffold(
+      body: TableCalendar(
+        focusedDay: DateTime.now(),
+        firstDay: DateTime(2025),
+        lastDay: DateTime(2100),
+        headerStyle: HeaderStyle(
+          formatButtonVisible: false,
+          titleCentered: true,
+          titleTextStyle: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        calendarStyle: CalendarStyle(
+          isTodayHighlighted: true,
+          defaultDecoration: defaultBoxDecoration,
+          weekendDecoration: defaultBoxDecoration,
+          selectedDecoration: defaultBoxDecoration.copyWith(
+            border: Border.all(
+              color: MAIN_COLOR,
+            )
+          ),
+          todayDecoration: defaultBoxDecoration.copyWith(
+            color: MAIN_COLOR,
+          ),
+          outsideDecoration: defaultBoxDecoration.copyWith(
+            border: Border.all(
+              color: Colors.transparent,
+            )
+          ),
+          defaultTextStyle: defaultTextStyle,
+          weekendTextStyle: defaultTextStyle,
+          selectedTextStyle: defaultTextStyle.copyWith(
+            color: MAIN_COLOR,
+          ),
+        ),
+        selectedDayPredicate: (DateTime date) {
+          if (selectedDay == null) return false;
+
+          return date.isAtSameMomentAs(selectedDay!);
+        },
+        onDaySelected: (DateTime selectedDay, DateTime focusedDay) {
+          setState(() {
+            this.selectedDay = selectedDay;
+          });
+        },
+      ),
+    );
+  }
+}

--- a/lib/common/view/root_tab.dart
+++ b/lib/common/view/root_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:team_project_front/calendar/view/calendar_screen.dart';
 import 'package:team_project_front/common/component/custom_appbar_root_tab.dart';
 import 'package:team_project_front/common/component/custom_navigation_bar.dart';
 import 'package:team_project_front/home/view/home.dart';
@@ -59,7 +60,7 @@ class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
           // MapScreen()
           Center(child: Container(child: Text('지도'))),
           // CalendarScreen()
-          Center(child: Container(child: Text('캘린더'))),
+          CalendarScreen(),
           // MyScreen()
           MyScreen(),
         ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,8 +4,13 @@ import 'package:team_project_front/init/view/init.dart';
 import 'package:team_project_front/login/view/login.dart';
 import 'package:team_project_front/report/view/create_report.dart';
 import 'package:team_project_front/signup/view/signup_agreement.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await initializeDateFormatting();
+
   runApp(_App());
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -232,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -312,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: ba2cd5af24ff20a0b8d609cec3f40e5b0744d2a71804a2616ae086b9c19d19a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -349,6 +365,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: "0c0c6219878b363a2d5f40c7afb159d845f253d061dc3c822aa0d5fe0f721982"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,7 +233,7 @@ packages:
     source: hosted
     version: "0.2.1+1"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   email_validator: ^3.0.0
   image_picker: ^1.1.2
   fl_chart: ^1.0.0
+  table_calendar: ^3.2.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   image_picker: ^1.1.2
   fl_chart: ^1.0.0
   table_calendar: ^3.2.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 일정 개수에 따른 마커(최대 3개) 구현함.
- table_calendar 패키지와 intl 패키지 yaml파일에 추가 => **pub get** 해주세요
- 일정 삭제 => 스와이프로 가능
- 일정 수정 가능
- 행 간격이 띄어지지 않는 이슈로 인하여 피그마와 UI 구현이 일부 다름

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/943a9d90-8be5-40d0-871d-8fa717efa3ba)
![image](https://github.com/user-attachments/assets/5ffc9115-407a-4f93-8eff-e198cfac4828)
![image](https://github.com/user-attachments/assets/5bcb03b9-189f-4a6c-970e-f804b0d631f6)
![image](https://github.com/user-attachments/assets/ea83ab44-36f3-4b91-967e-775bc311e56b)



<br/>


## ➕ 이슈 링크

- [frontend #22 ]
- [frontend #23 ]

<br/>
