### PR TITLE
✨ [Feat] 마이페이지 부모(회원) 관련 API 연결 및 UI 적용

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ class _App extends StatelessWidget {
       // home: RootTab(),
       // Named Routes 적용 화면 개발시 initialRoute를 바꿔주면서 진행하면 편리합니다.
       // ex) login 화면 개발 중이라면 initialRoute: '/login',
-      initialRoute: '/home',
+      initialRoute: '/report',
       routes: {
         '/': (context) => InitScreen(),
         '/home': (context) => RootTab(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ class _App extends StatelessWidget {
       // home: RootTab(),
       // Named Routes 적용 화면 개발시 initialRoute를 바꿔주면서 진행하면 편리합니다.
       // ex) login 화면 개발 중이라면 initialRoute: '/login',
-      initialRoute: '/login',
+      initialRoute: '/home',
       routes: {
         '/': (context) => InitScreen(),
         '/home': (context) => RootTab(),

--- a/lib/mypage/component/email_input.dart
+++ b/lib/mypage/component/email_input.dart
@@ -6,6 +6,7 @@ class EmailInput extends StatefulWidget {
   final TextEditingController emailDomainController;
   final String? customEmailDomain;
   final ValueChanged<String>? onCustomEmailDomainChanged;
+  final bool isReadOnly;
 
   const EmailInput({
     super.key,
@@ -13,6 +14,7 @@ class EmailInput extends StatefulWidget {
     required this.emailDomainController,
     this.customEmailDomain,
     this.onCustomEmailDomainChanged,
+    this.isReadOnly = false,
   });
 
   @override
@@ -74,15 +76,13 @@ class _EmailInputState extends State<EmailInput> {
                 height: 60,
                 child: TextFormField(
                   controller: widget.emailIdController,
+                  enabled: !widget.isReadOnly,
                   decoration: InputDecoration(
+                    filled: widget.isReadOnly,
+                    fillColor: widget.isReadOnly ? Colors.grey[200] : null,
                     hintText: '이메일',
                     hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
-                    border: OutlineInputBorder(),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: const BorderSide(color: MAIN_COLOR, width: 2.0),
-                    ),
-                    enabledBorder: OutlineInputBorder(
+                    border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
                     ),
@@ -103,10 +103,13 @@ class _EmailInputState extends State<EmailInput> {
                 height: 60,
                 child: TextFormField(
                   controller: customDomainController,
+                  enabled: !widget.isReadOnly,
                   onChanged: (value) {
                     widget.onCustomEmailDomainChanged?.call(value);
                   },
                   decoration: InputDecoration(
+                    filled: widget.isReadOnly,
+                    fillColor: widget.isReadOnly ? Colors.grey[200] : null,
                     hintText: '직접 입력',
                     hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
                     border: OutlineInputBorder(),
@@ -125,35 +128,43 @@ class _EmailInputState extends State<EmailInput> {
                   :
               SizedBox(
                 height: 60,
-                child: DropdownButtonFormField<String>(
-                  value: selectedDomain,
-                  items: emailDomains
-                      .map((domain) => DropdownMenuItem(
-                    value: domain,
-                    child: Text(domain),
-                  ))
-                      .toList(),
-                  onChanged: (value) {
-                    setState(() {
-                      selectedDomain = value!;
-                      if (value != '직접입력') {
-                        widget.emailDomainController.text = value;
-                        widget.onCustomEmailDomainChanged?.call('');
-                        customDomainController.clear();
-                      } else {
-                        widget.emailDomainController.clear();
-                        customDomainController.text = widget.customEmailDomain ?? '';
-                        widget.onCustomEmailDomainChanged?.call(customDomainController.text);
-                      }
-                    });
-                  },
-                  decoration: InputDecoration(
-                    hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
-                    enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
+                child: IgnorePointer(
+                  ignoring: widget.isReadOnly,
+                  child: DropdownButtonFormField<String>(
+                    value: selectedDomain,
+                    items: emailDomains.map((domain) {
+                      return DropdownMenuItem(
+                        value: domain,
+                        child: Text(domain),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      setState(() {
+                        selectedDomain = value!;
+                        if (value != '직접입력') {
+                          widget.emailDomainController.text = value;
+                          widget.onCustomEmailDomainChanged?.call('');
+                          customDomainController.clear();
+                        } else {
+                          widget.emailDomainController.clear();
+                          customDomainController.text = widget.customEmailDomain ?? '';
+                          widget.onCustomEmailDomainChanged?.call(customDomainController.text);
+                        }
+                      });
+                    },
+                    decoration: InputDecoration(
+                      filled: widget.isReadOnly,
+                      fillColor: widget.isReadOnly ? Colors.grey[200] : null,
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: const BorderSide(color: MAIN_COLOR, width: 2.0),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(color: ICON_GREY_COLOR, width: 1.5),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
                     ),
-                    contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 10),
                   ),
                 ),
               ),

--- a/lib/mypage/component/email_input.dart
+++ b/lib/mypage/component/email_input.dart
@@ -4,11 +4,15 @@ import 'package:team_project_front/common/const/colors.dart';
 class EmailInput extends StatefulWidget {
   final TextEditingController emailIdController;
   final TextEditingController emailDomainController;
+  final String? customEmailDomain;
+  final ValueChanged<String>? onCustomEmailDomainChanged;
 
   const EmailInput({
     super.key,
     required this.emailIdController,
     required this.emailDomainController,
+    this.customEmailDomain,
+    this.onCustomEmailDomainChanged,
   });
 
   @override
@@ -17,12 +21,31 @@ class EmailInput extends StatefulWidget {
 
 class _EmailInputState extends State<EmailInput> {
   final List<String> emailDomains = ['gmail.com', 'naver.com', '직접입력'];
-  String selectedDomain = 'gmail.com';
+  late String selectedDomain;
+  late TextEditingController customDomainController;
 
   @override
   void initState() {
     super.initState();
-    widget.emailDomainController.text = selectedDomain;
+
+    final currentDomain = widget.emailDomainController.text;
+    if (currentDomain == 'gmail.com' || currentDomain == 'naver.com') {
+      selectedDomain = currentDomain;
+    } else {
+      selectedDomain = '직접입력';
+    }
+
+    customDomainController = TextEditingController(
+      text: widget.customEmailDomain ?? (selectedDomain == '직접입력' ? currentDomain : ''),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant EmailInput oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.customEmailDomain != oldWidget.customEmailDomain) {
+      customDomainController.text = widget.customEmailDomain ?? '';
+    }
   }
 
   @override
@@ -79,7 +102,10 @@ class _EmailInputState extends State<EmailInput> {
                   ? SizedBox(
                 height: 60,
                 child: TextFormField(
-                  controller: widget.emailDomainController,
+                  controller: customDomainController,
+                  onChanged: (value) {
+                    widget.onCustomEmailDomainChanged?.call(value);
+                  },
                   decoration: InputDecoration(
                     hintText: '직접 입력',
                     hintStyle: TextStyle(color: INPUT_BORDER_COLOR),
@@ -112,8 +138,12 @@ class _EmailInputState extends State<EmailInput> {
                       selectedDomain = value!;
                       if (value != '직접입력') {
                         widget.emailDomainController.text = value;
+                        widget.onCustomEmailDomainChanged?.call('');
+                        customDomainController.clear();
                       } else {
                         widget.emailDomainController.clear();
+                        customDomainController.text = widget.customEmailDomain ?? '';
+                        widget.onCustomEmailDomainChanged?.call(customDomainController.text);
                       }
                     });
                   },

--- a/lib/mypage/models/guardian_profile.dart
+++ b/lib/mypage/models/guardian_profile.dart
@@ -9,6 +9,7 @@ class GuardianProfile {
   final File? image;
   final String email;
   final String password;
+  final String socialType;
 
   GuardianProfile({
     required this.name,
@@ -19,5 +20,6 @@ class GuardianProfile {
     this.image,
     required this.email,
     required this.password,
+    required this.socialType,
   });
 }

--- a/lib/mypage/view/add_profile_symptoms_screen.dart
+++ b/lib/mypage/view/add_profile_symptoms_screen.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/complete_dialog.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/mypage/component/illness_selctor.dart';
@@ -90,7 +91,7 @@ class _AddProfileSymptomsScreenState extends State<AddProfileSymptomsScreen> {
 
     try {
       final resp = await dio.post(
-        'https://momfy.kr/api/children',
+        '$base_URL/children',
         data: requestBody,
         options: Options(
           headers: {

--- a/lib/mypage/view/edit_baby_profile.dart
+++ b/lib/mypage/view/edit_baby_profile.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/component/yes_or_no_dialog.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/main.dart';
@@ -26,7 +27,7 @@ Future<ProfileInfo?> fetchChildDetail({
 
   try {
     final resp = await dio.get(
-      'https://momfy.kr/api/children/$childId',
+      '$base_URL/children/$childId',
       options: Options(
         headers: {
           'Authorization': accessToken,
@@ -181,7 +182,7 @@ class _EditBabyProfileState extends State<EditBabyProfile> {
 
           try {
             final resp = await dio.delete(
-              'https://momfy.kr/api/children/$childId',
+              '$base_URL/children/$childId',
               options: Options(
                 headers: {
                   'Authorization': accessToken,

--- a/lib/mypage/view/edit_my_profile.dart
+++ b/lib/mypage/view/edit_my_profile.dart
@@ -32,6 +32,7 @@ class _EditMyProfileState extends State<EditMyProfile> {
   String? monthText;
   String? dayText;
   String? gender;
+  String? social;
   File? image;
 
   String? customEmailDomain;
@@ -70,6 +71,7 @@ class _EditMyProfileState extends State<EditMyProfile> {
         image: null,
         email: email,
         password: '',
+        socialType: data['socialType'],
       );
 
       nameController = TextEditingController(text: myProfile.name);
@@ -140,9 +142,12 @@ class _EditMyProfileState extends State<EditMyProfile> {
       gender: gender!,
       image: image,
       email: '${emailIdController.text}@$domain',
-      password: passwordController.text.isEmpty
-        ? myProfile.password
-        : passwordController.text,
+      password: myProfile.socialType == 'LOCAL'
+          ? (passwordController.text.isEmpty
+          ? myProfile.password
+          : passwordController.text)
+          : '',
+      socialType: myProfile.socialType,
     );
 
     Navigator.of(context).pop();
@@ -221,18 +226,20 @@ class _EditMyProfileState extends State<EditMyProfile> {
                 onGenderSelected: (val) => setState(() => gender = val),
               ),
               SizedBox(height: 20),
-              Text(
-                '새 비밀번호',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
+              if(myProfile.socialType == 'LOCAL') ...[
+                Text(
+                  '새 비밀번호',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
-              ),
-              SizedBox(height: 10),
-              PasswordInput(
-                passwordController: passwordController,
-                confirmController: confirmPasswordController,
-              ),
+                SizedBox(height: 10),
+                PasswordInput(
+                  passwordController: passwordController,
+                  confirmController: confirmPasswordController,
+                ),
+              ],
               SizedBox(height: 40),
             ],
           ),

--- a/lib/mypage/view/edit_my_profile.dart
+++ b/lib/mypage/view/edit_my_profile.dart
@@ -208,6 +208,7 @@ class _EditMyProfileState extends State<EditMyProfile> {
                     customEmailDomain = val;
                   });
                 },
+                isReadOnly: true,
               ),
               SizedBox(height: 10),
               ProfileNameInput(controller: nameController),

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
@@ -254,7 +255,7 @@ Future<List<ProfileInfo>> fetchChildren(String accessToken) async {
 
   try {
     final resp = await dio.get(
-      'https://momfy.kr/api/children',
+      '$base_URL/children',
       options: Options(
         headers: {
           'Authorization': accessToken,

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -26,11 +26,33 @@ class _MyScreenState extends State<MyScreen> {
   final String accessToken = 'Bearer ACCESS_TOKEN';
 
   List<ProfileInfo> members = [];
+  String name = '';
+  String email = '';
 
   @override
   void initState() {
     super.initState();
+    loadMyInfo();
     loadChildren();
+  }
+
+  void loadMyInfo() async {
+    try {
+      final dio = Dio();
+      final response = await dio.get(
+        '$base_URL/my',
+        options: Options(
+          headers: {'Authorization': accessToken},
+        ),
+      );
+      final result = response.data['result'];
+      setState(() {
+        name = result['name'] ?? '';
+        email = result['email'] ?? '';
+      });
+    } catch(e) {
+      print('내 정보 호출 실패: $e');
+    }
   }
 
   void loadChildren() async {
@@ -47,6 +69,8 @@ class _MyScreenState extends State<MyScreen> {
         SizedBox(height: 24),
         MyProfile(
           image: image,
+          name: name,
+          email: email,
           onPressedChangePic: () => handleImagePick(
             context: context,
             onImageSelected: (selectedImage) {
@@ -98,11 +122,15 @@ class _MyScreenState extends State<MyScreen> {
 }
 
 class MyProfile extends StatelessWidget {
+  final String name;
+  final String email;
   File? image;
   final GestureTapCallback? onPressedChangePic;
   final VoidCallback? onPressedChangeProfile;
 
   MyProfile({
+    required this.name,
+    required this.email,
     required this.image,
     required this.onPressedChangePic,
     required this.onPressedChangeProfile,
@@ -124,7 +152,7 @@ class MyProfile extends StatelessWidget {
         ),
         SizedBox(height: 12),
         Text(
-          '홍길동',
+          name,
           style: TextStyle(
             fontWeight: FontWeight.w900,
             fontSize: 24,
@@ -132,7 +160,7 @@ class MyProfile extends StatelessWidget {
         ),
         SizedBox(height: 4),
         Text(
-          'jh010303',
+          email,
           style: TextStyle(
             color: Colors.grey,
             fontSize: 12,

--- a/lib/report/model/report_info.dart
+++ b/lib/report/model/report_info.dart
@@ -14,7 +14,9 @@ class ReportInfo {
   // 외출 기록
   final String outingRecord;
   // 진단 질환들
-  final List<String> illnessTypes;
+  final List<String> illnesses;
+  // AI 분석 설명
+  final String special;
 
   final ReportStats? day1;
   final ReportStats? day3;
@@ -27,7 +29,8 @@ class ReportInfo {
     required this.symptoms,
     required this.etcSymptom,
     required this.outingRecord,
-    required this.illnessTypes,
+    required this.illnesses,
+    required this.special,
     this.day1,
     this.day3,
     this.day7,
@@ -41,7 +44,8 @@ class ReportInfo {
       symptoms: List<String>.from(json['symptoms'] ?? []),
       etcSymptom: json['etc_symptom'] ?? '',
       outingRecord: json['outing'] ?? '',
-      illnessTypes: List<String>.from(json['illnessTypes'] ?? []),
+      illnesses: List<String>.from(json['illnesses'] ?? []),
+      special: json['special'] ?? '',
       day1: json['day1'] != null ? ReportStats.fromJson(json['day1']) : null,
       day3: json['day3'] != null ? ReportStats.fromJson(json['day3']) : null,
       day7: json['day7'] != null ? ReportStats.fromJson(json['day7']) : null,

--- a/lib/report/view/change_report.dart
+++ b/lib/report/view/change_report.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/report/component/custom_text_input.dart';
 import 'package:team_project_front/report/model/report_info.dart';
 import 'package:team_project_front/report/view/create_report.dart';
@@ -60,7 +61,7 @@ class _ChangeReportState extends State<ChangeReport> {
           .toList();
 
       final response = await dio.patch(
-        'https://momfy.kr/api/reports/${widget.report.reportId}',
+        '$base_URL/reports/${widget.report.reportId}',
         data: {
           'symptoms': convertedSymptoms,
           'etc_symptom': etcController.text.trim(),

--- a/lib/report/view/report.dart
+++ b/lib/report/view/report.dart
@@ -41,7 +41,7 @@ class _ReportState extends State<Report> {
 
   // 홈화면에서 아이 선택 후 리포트 생성할 것이므로
   // childId는 현재 임의로 설정
-  late final int childId = 28;
+  late final int childId = 15;
 
   @override
   void initState() {
@@ -271,7 +271,8 @@ Future<PaginatedReportResponse> fetchReportList({
         ),
         etcSymptom: e['etc_symptom'] ?? '',
         outingRecord: e['outing'] ?? '',
-        illnessTypes: [],
+        illnesses: List<String>.from(e['illnesses'] ?? []),
+        special: e['special'] ?? '',
       );
     }).toList();
 

--- a/lib/report/view/report.dart
+++ b/lib/report/view/report.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/report/component/report_card.dart';
 import 'package:team_project_front/report/model/report_info.dart';
@@ -91,7 +92,7 @@ class _ReportState extends State<Report> {
 
     try {
       final resp = await dio.delete(
-        'https://momfy.kr/api/reports/$reportId',
+        '$base_URL/reports/$reportId',
         options: Options(
           headers: {
             'Authorization': accessToken

--- a/lib/report/view/report.dart
+++ b/lib/report/view/report.dart
@@ -41,7 +41,7 @@ class _ReportState extends State<Report> {
 
   // 홈화면에서 아이 선택 후 리포트 생성할 것이므로
   // childId는 현재 임의로 설정
-  late final int childId = 15;
+  late final int childId = 28;
 
   @override
   void initState() {

--- a/lib/report/view/result_report.dart
+++ b/lib/report/view/result_report.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/component/temperature_chart_widget.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/report/model/report_info.dart';
 import 'package:team_project_front/report/view/report.dart';
@@ -41,7 +42,7 @@ class _ResultReportState extends State<ResultReport> {
   Future<ReportInfo> fetchReport() async {
     try {
       final response = await Dio().get(
-        'https://momfy.kr/api/reports/${widget.reportId}',
+        '$base_URL/reports/${widget.reportId}',
         options: Options(
           headers: {
             'Authorization': accessToken,

--- a/lib/report/view/result_report.dart
+++ b/lib/report/view/result_report.dart
@@ -104,9 +104,9 @@ class _ResultReportState extends State<ResultReport> {
                 if (report.etcSymptom.trim().isNotEmpty)
                   _EtcSymptomsWidget(etcSymptom: report.etcSymptom),
                 const SizedBox(height: 20),
-                _DiagnosisWidget(illnesses: report.illnessTypes),
+                _DiagnosisWidget(illnesses: report.illnesses),
                 const SizedBox(height: 10),
-                _SupplementaryExplanationWidget(outingRecord: report.outingRecord),
+                _SupplementaryExplanationWidget(special: report.special),
                 const SizedBox(height: 40),
                 _ChartSectionWidget(
                   title: '리포트 생성 시점 체온',
@@ -275,10 +275,10 @@ class _DiagnosisWidget extends StatelessWidget {
 }
 
 class _SupplementaryExplanationWidget extends StatelessWidget {
-  final String outingRecord;
+  final String special;
 
   const _SupplementaryExplanationWidget({
-    required this.outingRecord,
+    required this.special,
   });
 
   @override
@@ -310,9 +310,9 @@ class _SupplementaryExplanationWidget extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
           ),
           child: Text(
-            outingRecord.trim().isNotEmpty
-                ? outingRecord.trim()
-                : '입력된 외출 기록이 없습니다.',
+            special.trim().isNotEmpty
+                ? special.trim()
+                : '보충 설명이 없습니다.',
             style: TextStyle(fontWeight: FontWeight.w500, fontSize: 14),
           ),
         ),

--- a/lib/report/view/symptom_summary_dialog.dart
+++ b/lib/report/view/symptom_summary_dialog.dart
@@ -132,7 +132,8 @@ Future<ReportInfo?> createReport({
     symptoms: List<String>.from(result['symptoms']),
     etcSymptom: result['etc_symptom'] ?? '',
     outingRecord: result['outing'] ?? '',
-    illnessTypes: [], // 추후 api 변경 되면 받아올 예정.
+    illnesses: List<String>.from(result['illnesses'] ?? []),
+    special: result['special'] ?? '',// 추후 api 변경 되면 받아올 예정.
     day1: ReportStats.fromJson(result['day1']),
     day3: ReportStats.fromJson(result['day3']),
     day7: ReportStats.fromJson(result['day7']),

--- a/lib/report/view/symptom_summary_dialog.dart
+++ b/lib/report/view/symptom_summary_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
 import 'package:team_project_front/report/model/report_info.dart';
 import 'package:team_project_front/report/view/result_report.dart';
@@ -109,7 +110,7 @@ Future<ReportInfo?> createReport({
   final accessToken = 'Bearer ACCESS_TOKEN';
 
   final response = await dio.post(
-    'https://momfy.kr/api/reports/$childId',
+    '$base_URL/reports/$childId',
     data: {
       'symptoms': convertedSymptoms,
       'etc_symptom': etcSymptom,

--- a/lib/settings/view/settings_screen.dart
+++ b/lib/settings/view/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/yes_or_no_dialog.dart';
 import 'package:team_project_front/common/const/colors.dart';
@@ -67,13 +68,55 @@ class SettingsScreen extends StatelessWidget {
           '회원 탈퇴 시 기록하신 모든 데이터가\n'
           '삭제되어 복구가 불가능합니다.\n'
           '정말 탈퇴하시겠습니까?',
-        onPressedYes: () {
-          // 회원 탈퇴 처리 로직
+        onPressedYes: () async {
+          withdrawUser(context);
         },
         yesText: '예',
         noText: '아니오',
       ),
     );
+  }
+}
+
+// 추후에 accessToken FlutterSecureStorage에서 가져오도록 변경 예정
+final String accessToken = 'Bearer ACCESS_TOKEN';
+
+Future<void> withdrawUser(BuildContext context) async {
+  final dio = Dio();
+
+  try {
+    Navigator.of(context).pop();
+
+    final response = await dio.delete(
+      'https://momfy.kr/api/my',
+      options: Options(headers: {
+        'Authorization': accessToken,
+      }),
+    );
+
+    if(response.data['isSuccess'] == true) {
+      // 토큰 삭제
+      //await storage.deleteAll();
+      if (context.mounted) {
+        Navigator.of(context).pushNamedAndRemoveUntil('/login', (route) => false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('회원 탈퇴가 완료되었습니다.')),
+        );
+      } else {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('탈퇴 실패: ${response.data['message']}')),
+          );
+        }
+      }
+    }
+  } catch(e) {
+    print('회원 탈퇴 오류: $e');
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('탈퇴 중 오류가 발생했습니다.')),
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 부모(회원)와 관련된 API(부모 정보 조회, 수정, 삭제(탈퇴))들을 연결했습니다.
- 회원 탈퇴는 API 연결은 했지만 서버에서 soft delete 이슈로 회원 정보는 지워지지만 그대로 로그인 등 다른 기능은 작동됩니다.
- **회원 탈퇴 api를 테스트할 시에 따로 계정을 생성해서 해주세요. (hyunbini02@naver.com이외의 계정으로 테스트 해주세요)**
- 아이, 부모(회원)의 프로필 이미지는 캘린더 api 연결 후 구현하겠습니다.(아직 연결 x)
  <br/>
- 로그인하고 네비게이션이 안보이는 이슈로 accessToken은 일단 하드 코딩으로 파일마다 작성하도록 했습니다. 고쳐지면 storage로부터 불러오도록 코드 변경하겠습니다! => 현재 pr의 api 연결 확인하시려면 mypage 폴더의 my_screen.dart, edit_my_profile.dart,  settings 폴더의 settings_screen.dart에 accessToken 입력하시면 됩니다.

<br/>

- 추가로 리포트 결과에 이전 진단 질환과 AI가 설명해준 요약 결과를 볼 수 있도록 수정했습니다.

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>


## ➕ 이슈 링크

- [frontend #47]

<br/>
