### PR TITLE
🔨 [Refactor] accessToken 처리 개선 및 이미지 처리 기능 추가

### DIFF
--- a/lib/common/component/temperature_chart_widget.dart
+++ b/lib/common/component/temperature_chart_widget.dart
@@ -147,7 +147,7 @@ class _TemperatureChartWidgetState extends State<TemperatureChartWidget> {
   Map<String, double> _getYRange() {
     switch (widget.chartType) {
       case ChartType.bodyTemp:
-        return {'min': 35, 'max': 42, 'interval': 1};
+        return {'min': 35, 'max': 39, 'interval': 1};
       case ChartType.roomTemp:
         return {'min': 3, 'max': 30, 'interval': 3};
       case ChartType.humidity:

--- a/lib/mypage/component/profile_image_with_add_icon.dart
+++ b/lib/mypage/component/profile_image_with_add_icon.dart
@@ -4,6 +4,7 @@ import 'package:team_project_front/common/const/colors.dart';
 
 class ProfileImageWithAddIcon extends StatelessWidget {
   final File? image;
+  final String? networkImageUrl;
   final double profileIconSize;
   final double addImageIconSize;
   final double bottom;
@@ -13,6 +14,7 @@ class ProfileImageWithAddIcon extends StatelessWidget {
 
   const ProfileImageWithAddIcon({
     required this.image,
+    required this.networkImageUrl,
     required this.profileIconSize,
     required this.addImageIconSize,
     required this.bottom,
@@ -24,19 +26,31 @@ class ProfileImageWithAddIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget imageWidget;
+
+    if (image != null) {
+      imageWidget = CircleAvatar(
+        radius: radius,
+        backgroundColor: Colors.white,
+        backgroundImage: FileImage(image!),
+      );
+    } else if (networkImageUrl != null && networkImageUrl!.isNotEmpty) {
+      imageWidget = CircleAvatar(
+        radius: radius,
+        backgroundColor: Colors.white,
+        backgroundImage: NetworkImage(networkImageUrl!),
+      );
+    } else {
+      imageWidget = Icon(
+        Icons.account_circle,
+        size: profileIconSize,
+        color: ICON_GREY_COLOR,
+      );
+    }
+
     return Stack(
       children: [
-        image != null
-            ? CircleAvatar(
-          radius: radius,
-          backgroundColor: Colors.white,
-          backgroundImage: image != null ? FileImage(image!) : null,
-        )
-            : Icon(
-          Icons.account_circle,
-          size: profileIconSize,
-          color: ICON_GREY_COLOR,
-        ),
+        imageWidget,
         Positioned(
           bottom: bottom,
           right: right,

--- a/lib/mypage/component/profile_image_with_add_icon.dart
+++ b/lib/mypage/component/profile_image_with_add_icon.dart
@@ -11,6 +11,7 @@ class ProfileImageWithAddIcon extends StatelessWidget {
   final double right;
   final double radius;
   final GestureTapCallback? onPressedChangePic;
+  final bool showAddIcon;
 
   const ProfileImageWithAddIcon({
     required this.image,
@@ -21,6 +22,7 @@ class ProfileImageWithAddIcon extends StatelessWidget {
     required this.right,
     required this.radius,
     required this.onPressedChangePic,
+    this.showAddIcon = true,
     super.key,
   });
 
@@ -51,25 +53,26 @@ class ProfileImageWithAddIcon extends StatelessWidget {
     return Stack(
       children: [
         imageWidget,
-        Positioned(
-          bottom: bottom,
-          right: right,
-          child: GestureDetector(
-            onTap: onPressedChangePic,
-            child: Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Colors.grey[50],
-                shape: BoxShape.circle,
-              ),
-              child: Icon(
-                Icons.add_a_photo,
-                size: addImageIconSize,
-                color: ICON_GREY_COLOR,
+        if(showAddIcon)
+          Positioned(
+            bottom: bottom,
+            right: right,
+            child: GestureDetector(
+              onTap: onPressedChangePic,
+              child: Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: Colors.grey[50],
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.add_a_photo,
+                  size: addImageIconSize,
+                  color: ICON_GREY_COLOR,
+                ),
               ),
             ),
-          ),
-        ),
+          )
       ],
     );
   }

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -81,23 +81,23 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Center(
-                child: ProfileImageWithAddIcon(
-                  image: image,
-                  profileIconSize: 90,
-                  addImageIconSize: 18,
-                  bottom: 0,
-                  right: -5,
-                  radius: 50,
-                  onPressedChangePic:
-                      () => handleImagePick(
-                        context: context,
-                        onImageSelected: (selectedImage) {
-                          setState(() {
-                            image = selectedImage;
-                          });
-                        },
-                      ),
-                ),
+                // child: ProfileImageWithAddIcon(
+                //   image: image,
+                //   profileIconSize: 90,
+                //   addImageIconSize: 18,
+                //   bottom: 0,
+                //   right: -5,
+                //   radius: 50,
+                //   onPressedChangePic:
+                //       () => handleImagePick(
+                //         context: context,
+                //         onImageSelected: (selectedImage) {
+                //           setState(() {
+                //             image = selectedImage;
+                //           });
+                //         },
+                //       ),
+                // ),
               ),
               SizedBox(height: 15),
               Text(

--- a/lib/mypage/view/add_profile_screen.dart
+++ b/lib/mypage/view/add_profile_screen.dart
@@ -5,10 +5,8 @@ import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/mypage/component/profile_birth_input.dart';
 import 'package:team_project_front/mypage/component/profile_body_info_input.dart';
 import 'package:team_project_front/mypage/component/profile_gender_selector.dart';
-import 'package:team_project_front/mypage/component/profile_image_with_add_icon.dart';
 import 'package:team_project_front/mypage/component/profile_name_input.dart';
 import 'package:team_project_front/mypage/models/profile_info.dart';
-import 'package:team_project_front/mypage/utils/image_pick_handler.dart';
 import 'package:team_project_front/mypage/utils/validators.dart';
 import 'package:team_project_front/mypage/view/add_profile_symptoms_screen.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
@@ -80,26 +78,6 @@ class _AddProfileScreenState extends State<AddProfileScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Center(
-                // child: ProfileImageWithAddIcon(
-                //   image: image,
-                //   profileIconSize: 90,
-                //   addImageIconSize: 18,
-                //   bottom: 0,
-                //   right: -5,
-                //   radius: 50,
-                //   onPressedChangePic:
-                //       () => handleImagePick(
-                //         context: context,
-                //         onImageSelected: (selectedImage) {
-                //           setState(() {
-                //             image = selectedImage;
-                //           });
-                //         },
-                //       ),
-                // ),
-              ),
-              SizedBox(height: 15),
               Text(
                 '우리 아이 정보를 알려주세요',
                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.w900),

--- a/lib/mypage/view/add_profile_symptoms_screen.dart
+++ b/lib/mypage/view/add_profile_symptoms_screen.dart
@@ -4,6 +4,7 @@ import 'package:team_project_front/common/component/complete_dialog.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/mypage/component/illness_selctor.dart';
 import 'package:team_project_front/mypage/component/seizure_history_selector.dart';
@@ -46,8 +47,12 @@ class _AddProfileSymptomsScreenState extends State<AddProfileSymptomsScreen> {
       illnessList: selectedIllness.toList(),
     );
 
-    // 추후에 accessToken FlutterSecureStorage에서 가져오도록 변경 예정
-    final accessToken = 'Bearer ACCESS_TOKEN';
+    final token = await SecureStorageService.getAccessToken();
+    if (token == null) {
+      print('accessToken 없음. 요청 중단.');
+      return;
+    }
+    final accessToken = 'Bearer $token';
     final Dio dio = Dio();
     final birthdate =
         "${updatedProfileInfo.birthYear.padLeft(2, '0')}-${updatedProfileInfo.birthMonth.padLeft(2, '0')}-${updatedProfileInfo.birthDay.padLeft(2, '0')}";

--- a/lib/mypage/view/edit_baby_profile.dart
+++ b/lib/mypage/view/edit_baby_profile.dart
@@ -312,22 +312,22 @@ class _EditBabyProfileState extends State<EditBabyProfile> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Center(
-                child: ProfileImageWithAddIcon(
-                  image: image,
-                  profileIconSize: 90,
-                  addImageIconSize: 18,
-                  bottom: 0,
-                  right: -5,
-                  radius: 50,
-                  onPressedChangePic: () => handleImagePick(
-                    context: context,
-                    onImageSelected: (selectedImage) {
-                      setState(() {
-                        image = selectedImage;
-                      });
-                    },
-                  ),
-                ),
+                // child: ProfileImageWithAddIcon(
+                //   image: image,
+                //   profileIconSize: 90,
+                //   addImageIconSize: 18,
+                //   bottom: 0,
+                //   right: -5,
+                //   radius: 50,
+                //   onPressedChangePic: () => handleImagePick(
+                //     context: context,
+                //     onImageSelected: (selectedImage) {
+                //       setState(() {
+                //         image = selectedImage;
+                //       });
+                //     },
+                //   ),
+                // ),
               ),
               SizedBox(height: 15),
               Text(

--- a/lib/mypage/view/edit_my_profile.dart
+++ b/lib/mypage/view/edit_my_profile.dart
@@ -171,7 +171,7 @@ class _EditMyProfileState extends State<EditMyProfile> {
 
       if (response.data["isSuccess"] == true) {
         if (context.mounted) {
-          Navigator.of(context).pop(); // 이전 화면으로 이동
+          Navigator.of(context).pop(true);
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text("내 정보가 성공적으로 수정되었어요!")),
           );

--- a/lib/mypage/view/edit_my_profile.dart
+++ b/lib/mypage/view/edit_my_profile.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/const/base_url.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/mypage/component/email_input.dart';
 import 'package:team_project_front/mypage/component/password_input.dart';
 import 'package:team_project_front/mypage/component/profile_birth_input.dart';
@@ -40,18 +41,31 @@ class _EditMyProfileState extends State<EditMyProfile> {
   String? customEmailDomain;
   bool isLoading = true;
 
-  // 추후에 accessToken FlutterSecureStorage에서 가져오도록 변경 예정
-  final accessToken = 'Bearer ACCESS_TOKEN';
+  String? accessToken;
 
   @override
   void initState() {
     super.initState();
-    loadMyInfo();
     passwordController = TextEditingController();
     confirmPasswordController = TextEditingController();
+    initialize();
+  }
+
+  Future<void> initialize() async {
+    final token = await SecureStorageService.getAccessToken();
+
+    if (token == null) {
+      print('accessToken 없음! 로그인 필요');
+      return;
+    }
+
+    accessToken = 'Bearer $token';
+    await loadMyInfo();
   }
 
   Future<void> loadMyInfo() async {
+    if(accessToken == null) return;
+
     try {
       final dio = Dio();
       final response = await dio.get(
@@ -141,6 +155,8 @@ class _EditMyProfileState extends State<EditMyProfile> {
   }
 
   void onNextPressed() async {
+    if(accessToken == null) return;
+
     final dio = Dio();
     final domain = emailDomainController.text == '직접입력'
         ? customEmailDomain ?? ''

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -166,6 +166,7 @@ class MyProfile extends StatelessWidget {
           right: 4,
           radius: 70,
           onPressedChangePic: onPressedChangePic,
+          showAddIcon: false,
         ),
         SizedBox(height: 12),
         Text(

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -82,7 +82,11 @@ class _MyScreenState extends State<MyScreen> {
           onPressedChangeProfile: () {
             Navigator.of(context).push(
               MaterialPageRoute(builder: (_) => EditMyProfile())
-            );
+            ).then((value) {
+              if(value == true) {
+                loadMyInfo();
+              }
+            });
           },
         ),
         SizedBox(height: 36),

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -254,10 +254,10 @@ class FamilyProfile extends StatelessWidget {
                       CircleAvatar(
                         radius: 30,
                         backgroundColor: Colors.transparent,
-                        backgroundImage: profile.profileImage != null && profile.profileImage != "string"
+                        backgroundImage: profile.profileImage != null
                             ? NetworkImage(profile.profileImage!)
                             : null,
-                        child: (profile.profileImage == null || profile.profileImage == "string")
+                        child: (profile.profileImage == null || profile.profileImage!.isEmpty)
                             ? Icon(Icons.account_circle, size: 60, color: ICON_GREY_COLOR)
                             : null,
                       ),

--- a/lib/mypage/view/my_screen.dart
+++ b/lib/mypage/view/my_screen.dart
@@ -20,6 +20,7 @@ class MyScreen extends StatefulWidget {
 
 class _MyScreenState extends State<MyScreen> {
   File? image;
+  String? imageUrl;
   final ImagePicker picker = ImagePicker();
 
   // 추후에 accessToken FlutterSecureStorage에서 가져오도록 변경 예정
@@ -46,9 +47,17 @@ class _MyScreenState extends State<MyScreen> {
         ),
       );
       final result = response.data['result'];
+
+      final profileImage = result['profileImage'];
+
       setState(() {
         name = result['name'] ?? '';
         email = result['email'] ?? '';
+        imageUrl = (profileImage != null && profileImage.startsWith('http'))
+            ? profileImage
+            : profileImage != null
+            ? 'https://momfy-bucket.s3.ap-northeast-2.amazonaws.com/$profileImage'
+            : null;
       });
     } catch(e) {
       print('내 정보 호출 실패: $e');
@@ -69,6 +78,7 @@ class _MyScreenState extends State<MyScreen> {
         SizedBox(height: 24),
         MyProfile(
           image: image,
+          networkImageUrl: imageUrl,
           name: name,
           email: email,
           onPressedChangePic: () => handleImagePick(
@@ -129,6 +139,7 @@ class MyProfile extends StatelessWidget {
   final String name;
   final String email;
   File? image;
+  final String? networkImageUrl;
   final GestureTapCallback? onPressedChangePic;
   final VoidCallback? onPressedChangeProfile;
 
@@ -138,6 +149,7 @@ class MyProfile extends StatelessWidget {
     required this.image,
     required this.onPressedChangePic,
     required this.onPressedChangeProfile,
+    this.networkImageUrl,
     super.key,
   });
 
@@ -147,6 +159,7 @@ class MyProfile extends StatelessWidget {
       children: [
         ProfileImageWithAddIcon(
           image: image,
+          networkImageUrl: networkImageUrl,
           profileIconSize: 140,
           addImageIconSize: 24,
           bottom: 0,

--- a/lib/report/view/change_report.dart
+++ b/lib/report/view/change_report.dart
@@ -92,16 +92,27 @@ class _ChangeReportState extends State<ChangeReport> {
           headers: {
             'Authorization': accessToken,
           },
+          validateStatus: (status) => status != null && status < 500,
         ),
       );
 
-      if(response.statusCode == 200 && response.data['isSuccess'] == true) {
+      final resData = response.data;
+
+      if (response.statusCode == 200 && resData['isSuccess'] == true) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('리포트 수정이 완료되었습니다')),
         );
         Navigator.of(context).pop(true);
       } else {
-        throw Exception('수정 실패: ${response.data['message']}');
+        if (resData['code'] == 'FEVER_RECORD404') {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('홈캠을 통한 체온, 온습도 정보가 존재해야 합니다')),
+          );
+          Navigator.of(context).pushNamed('/home');
+          return;
+        }
+
+        throw Exception('수정 실패: ${resData['message']}');
       }
     } catch(e) {
       print('예외 발생: $e');

--- a/lib/report/view/change_report.dart
+++ b/lib/report/view/change_report.dart
@@ -78,7 +78,7 @@ class _ChangeReportState extends State<ChangeReport> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('리포트 수정이 완료되었습니다')),
         );
-        Navigator.of(context).pop();
+        Navigator.of(context).pop(true);
       } else {
         throw Exception('수정 실패: ${response.data['message']}');
       }

--- a/lib/report/view/report.dart
+++ b/lib/report/view/report.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/report/component/report_card.dart';
 import 'package:team_project_front/report/model/report_info.dart';
 import 'package:team_project_front/report/view/change_report.dart';
@@ -36,8 +37,7 @@ class _ReportState extends State<Report> {
   int cursor = 0;
   final int pageSize = 10;
 
-  // 임시 Access Token (추후 FlutterSecureStorage 등으로 교체 예정)
-  final String accessToken = 'Bearer ACCESS_TOKEN';
+  String? accessToken;
 
   // 홈화면에서 아이 선택 후 리포트 생성할 것이므로
   // childId는 현재 임의로 설정
@@ -46,7 +46,7 @@ class _ReportState extends State<Report> {
   @override
   void initState() {
     super.initState();
-    loadReports();
+    initialize();
 
     // childId = widget.childId; => 홈화면과 연결 시 주석 없앨 예정
 
@@ -59,8 +59,22 @@ class _ReportState extends State<Report> {
     });
   }
 
+  Future<void> initialize() async {
+    final token = await SecureStorageService.getAccessToken();
+    if (token == null) {
+      print('accessToken 없음! 로그인 필요');
+      return;
+    }
+
+    setState(() {
+      accessToken = 'Bearer $token';
+    });
+
+    loadReports();
+  }
+
   void loadReports() async {
-    if (isLoading || !hasNext) return;
+    if (isLoading || !hasNext || accessToken == null) return;
 
     setState(() => isLoading = true);
 
@@ -68,7 +82,7 @@ class _ReportState extends State<Report> {
       childId: childId,
       cursor: cursor,
       size: pageSize,
-      accessToken: accessToken,
+      accessToken: accessToken!,
     );
     setState(() {
       reportData.addAll(response.reports);
@@ -119,6 +133,12 @@ class _ReportState extends State<Report> {
 
   @override
   Widget build(BuildContext context) {
+    if (accessToken == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
       floatingActionButton: FloatingActionButton(
         onPressed: () {
@@ -176,7 +196,7 @@ class _ReportState extends State<Report> {
               onDismissed: (_) async {
                 final success = await deleteReport(
                   reportId: report.reportId,
-                  accessToken: accessToken,
+                  accessToken: accessToken!,
                 );
 
                 if (success) {

--- a/lib/report/view/report.dart
+++ b/lib/report/view/report.dart
@@ -213,7 +213,16 @@ class _ReportState extends State<Report> {
                       MaterialPageRoute(
                         builder: (_) => ChangeReport(report: report),
                       ),
-                    );
+                    ).then((result) => {
+                      if(result == true) {
+                        setState(() {
+                          reportData.clear();
+                          cursor = 0;
+                          hasNext = true;
+                          loadReports();
+                        })
+                      }
+                    });
                   },
                 ),
               ),

--- a/lib/report/view/result_report.dart
+++ b/lib/report/view/result_report.dart
@@ -119,7 +119,7 @@ class _ResultReportState extends State<ResultReport> {
                   createdAt: report.createdAt,
                 ),
                 _ChartSectionWidget(
-                  title: '리포트 생성 시점 온도',
+                  title: '리포트 생성 시점 방 온도',
                   chartType: ChartType.roomTemp,
                   chartData: {
                     PeriodType.day1: report.day1?.toTemperatureSpots() ?? [],
@@ -129,7 +129,7 @@ class _ResultReportState extends State<ResultReport> {
                   createdAt: report.createdAt,
                 ),
                 _ChartSectionWidget(
-                  title: '리포트 생성 시점 습도',
+                  title: '리포트 생성 시점 방 습도',
                   chartType: ChartType.humidity,
                   chartData: {
                     PeriodType.day1: report.day1?.toHumiditySpots() ?? [],

--- a/lib/report/view/result_report.dart
+++ b/lib/report/view/result_report.dart
@@ -5,6 +5,7 @@ import 'package:team_project_front/common/component/navigation_button.dart';
 import 'package:team_project_front/common/component/temperature_chart_widget.dart';
 import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/report/model/report_info.dart';
 import 'package:team_project_front/report/view/report.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
@@ -30,16 +31,33 @@ class ResultReport extends StatefulWidget {
 class _ResultReportState extends State<ResultReport> {
   late Future<ReportInfo> reportFuture;
 
-  // 임시 Access Token (추후 FlutterSecureStorage 등으로 교체 예정)
-  final String accessToken = 'Bearer ACCESS_TOKEN';
+  String? accessToken;
 
   @override
   void initState() {
     super.initState();
-    reportFuture = fetchReport();
+    initialize();
+  }
+
+  void initialize() async {
+    final token = await SecureStorageService.getAccessToken();
+
+    if (token == null) {
+      print('accessToken 없음! 로그인 필요');
+      return;
+    }
+
+    setState(() {
+      accessToken = 'Bearer $token';
+      reportFuture = fetchReport();
+    });
   }
 
   Future<ReportInfo> fetchReport() async {
+    if (accessToken == null) {
+      throw Exception('accessToken 없음');
+    }
+
     try {
       final response = await Dio().get(
         '$base_URL/reports/${widget.reportId}',
@@ -64,6 +82,12 @@ class _ResultReportState extends State<ResultReport> {
 
   @override
   Widget build(BuildContext context) {
+    if (accessToken == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(90),

--- a/lib/report/view/symptom_summary_dialog.dart
+++ b/lib/report/view/symptom_summary_dialog.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/report/model/report_info.dart';
 import 'package:team_project_front/report/view/result_report.dart';
 
@@ -106,8 +107,12 @@ Future<ReportInfo?> createReport({
 
   final convertedSymptoms = symptoms.map((s) => s.replaceAll(' ', '_')).toList();
 
-  // 추후에 accessToken FlutterSecureStorage에서 가져오도록 변경 예정
-  final accessToken = 'Bearer ACCESS_TOKEN';
+  final token = await SecureStorageService.getAccessToken();
+  if (token == null) {
+    throw Exception('로그인이 필요합니다');
+  }
+
+  final accessToken = 'Bearer $token';
 
   final response = await dio.post(
     '$base_URL/reports/$childId',

--- a/lib/settings/component/custom_appbar.dart
+++ b/lib/settings/component/custom_appbar.dart
@@ -14,33 +14,30 @@ class CustomAppbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        AppBar(
-          toolbarHeight: 70,
-          iconTheme: IconThemeData(
-            size: 30,
-            color: Colors.black,
-          ),
-          automaticallyImplyLeading: showBackButton ? true : false,
-          leading: showBackButton ? IconButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-            icon: Icon(Icons.arrow_back_ios_new),
-          ) : null,
-          title: Text(
-            title,
-            style: TextStyle(
-              fontSize: 25,
-              fontWeight: FontWeight.w900,
-            ),
-          ),
-          centerTitle: true,
-          actions: actions,
+    return AppBar(
+      scrolledUnderElevation: 0,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      toolbarHeight: 70,
+      iconTheme: IconThemeData(
+        size: 30,
+        color: Colors.black,
+      ),
+      automaticallyImplyLeading: showBackButton ? true : false,
+      leading: showBackButton ? IconButton(
+        onPressed: () {
+          Navigator.of(context).pop();
+        },
+        icon: Icon(Icons.arrow_back_ios_new),
+      ) : null,
+      title: Text(
+        title,
+        style: TextStyle(
+          fontSize: 25,
+          fontWeight: FontWeight.w900,
         ),
-      ],
+      ),
+      centerTitle: true,
+      actions: actions,
     );
   }
 }

--- a/lib/settings/view/settings_screen.dart
+++ b/lib/settings/view/settings_screen.dart
@@ -3,13 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/yes_or_no_dialog.dart';
 import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/main.dart';
 import 'package:team_project_front/settings/component/custom_appbar.dart';
 import 'package:team_project_front/settings/view/notification_settings_screen.dart';
 import 'package:team_project_front/settings/view/terms_screen.dart';
-
-// 추후에 accessToken FlutterSecureStorage에서 가져오도록 변경 예정
-final String accessToken = 'Bearer ACCESS_TOKEN';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -67,6 +65,14 @@ class SettingsScreen extends StatelessWidget {
 
   Future<void> logoutUser() async {
     final dio = Dio();
+    final token = await SecureStorageService.getAccessToken();
+
+    if (token == null) {
+      print('토큰이 없습니다. 로그아웃 불가');
+      return;
+    }
+
+    final accessToken = 'Bearer $token';
 
     try {
       final response = await dio.post(
@@ -77,8 +83,8 @@ class SettingsScreen extends StatelessWidget {
       );
 
       if (response.data['isSuccess'] == true) {
-        // 토큰 삭제
-        // await storage.deleteAll();
+        await SecureStorageService.deleteAccessToken();
+        // refreshToken 관련 로직 추가 예정
 
         navigatorKey.currentState?.pushNamedAndRemoveUntil(
           '/login',
@@ -114,6 +120,14 @@ class SettingsScreen extends StatelessWidget {
 
 Future<void> withdrawUser() async {
   final dio = Dio();
+  final token = await SecureStorageService.getAccessToken();
+
+  if (token == null) {
+    print('토큰이 없습니다. 탈퇴 불가');
+    return;
+  }
+
+  final accessToken = 'Bearer $token';
 
   try {
     final response = await dio.delete(
@@ -124,8 +138,8 @@ Future<void> withdrawUser() async {
     );
 
     if (response.data['isSuccess'] == true) {
-      // 토큰 삭제
-      // await storage.deleteAll();
+      await SecureStorageService.deleteAccessToken();
+      // refreshToken 관련 로직 추가 예정
 
       navigatorKey.currentState?.pushNamedAndRemoveUntil('/login', (route) => false);
     } else {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -150,6 +150,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  flutter_image_compress_common:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_common
+      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
+  flutter_image_compress_macos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_macos
+      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  flutter_image_compress_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_platform_interface
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_web:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_web
+      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -324,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -545,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   intl: ^0.20.2
   dio: ^5.8.0+1
   flutter_secure_storage: ^9.2.4
+  flutter_image_compress: ^2.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 이미지를 그대로 보내면 413에러가 발생해서 이미지 압축을 위한 flutter_image_compress 패키지를 추가했습니다! => **pub get** 해주세요!!
- 이제 부모(회원)과 아이의 프로필 이미지를 변경할 수 있습니다!
- accessToken을 SecureStorageService에서 가져오도록 수정(마이페이지, 리포트, 설정)했습니다. => 하드 코딩 모두 제거 => accessToken입력할 필요 없이 로그인 페이지에서 로그인만 하면 됩니다!
- 스크롤 가능한 페이지에서 스크롤할 시 appBar 부분의 배경색이 진해지는 버그를 수정했습니다!
- 아이 정보를 수정하거나 발열 리포트를 수정하고 전 페이지로 돌아가서 api를 추가적으로 요청할 수 있도록 변경했습니다!

- 발열 리포트 생성이나 수정 시 홈캠을 통한 체온, 온습도 데이터가 있어야 생성이나 수정할 수 있도록 변경했습니다.
- 발열 리포트 생성 => 404에러(체온, 온습도 데이터 존재 x) => home화면으로 이동
- 발열 리포트 생성 => 체온, 온습도 데이터 존재 o => 발열 리포트 생성 성공 
  <br/>
- 회원탈퇴 api는 아직 시도하면 안됩니닷! => 서버 soft delete 이슈
- refreshToken을 아직 받을 수 없으므로 refreshToken관련 로직은 작성 안했슴다!

- 캘린더 관련 api는 서버에서 계속 이슈가 발생해서 아직 코드 작성 못했습니다.
  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>


## ➕ 이슈 링크

- [frontend]

<br/>
